### PR TITLE
Allow for notification of GH actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,8 @@ updates:
     labels:
       - "Maintenance"
       - "Dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR is to allow the dependabot to get updates about the GH actions.