### PR TITLE
Migrate github workflow to pyansys/actions.

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -110,8 +110,7 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: [tests]
     runs-on: ubuntu-latest
-    #steps:
-#
+    steps:
     #  - name: "Release to the private PyPI repository"
     #    uses: pyansys/actions/release-pypi-private@v1
     #    with:
@@ -126,7 +125,7 @@ jobs:
     #      twine-username: "__token__"
     #      twine-token: ${{ secrets.PYPI_TOKEN }}
 #
-    #  - name: "Release to GitHub"
-    #    uses: pyansys/actions/release-github@v1
-    #    with:
-    #      library-name: ${{ env.PACKAGE_NAME }}
+    - name: "Release to GitHub"
+      uses: pyansys/actions/release-github@v1
+      with:
+        library-name: ${{ env.PACKAGE_NAME }}


### PR DESCRIPTION
Fix #80 
## Overview
[PyAnsys/actions](https://github.com/pyansys/actions) is the repository containing collection of reusable workflows and we are making use of that actions instead of replicating it again and again, so that we can reduce the maintenance and lines of codes. I am keeping the test as it is, because it needs docker.

## Notes:
Release is skipped to private and public PyPI by commenting.