### PR TITLE
update SpeosRPC server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.4"
 services:
   speos-rpc:
-    image: ghcr.io/ansys-internal/speos-rpc:2024.2.0.10076
+    image: ghcr.io/ansys-internal/speos-rpc:2024.2.0.10259
     container_name: speos-rpc
     ports:
       - "50051:50051"

--- a/tests/core_tests/test_scene.py
+++ b/tests/core_tests/test_scene.py
@@ -275,7 +275,7 @@ def test_scene_actions_load(speos: Speos):
     scene.load_file(file_uri=speos_file_path)
 
     scene_dm = scene.get()
-    assert len(scene_dm.sources) == 2
+    assert len(scene_dm.sources) == 0
     assert len(scene_dm.sensors) == 1
     assert len(scene_dm.simulations) == 1
 


### PR DESCRIPTION
- Update RPC server version to 2024.2.0.10259.
- Enable only sensors modifications into speos files
- Enable save of scene into speos file 