### PR TITLE
Support protobuf 5.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers=[
     "Private :: Do Not Upload",
 ]
 dependencies=[
+    "protobuf>=3.20,<6",
     "grpcio==1.62.1",
     "grpcio-health-checking==1.48.2",
     "ansys-api-speos==0.6.0",

--- a/src/ansys/speos/core/proto_message_utils.py
+++ b/src/ansys/speos/core/proto_message_utils.py
@@ -22,6 +22,7 @@
 
 from typing import Optional
 
+from google.protobuf import __version__ as protobuf_version
 from google.protobuf.json_format import MessageToJson
 from google.protobuf.message import Message
 
@@ -46,5 +47,10 @@ def protobuf_message_to_str(message: Message, with_full_name: Optional[bool] = T
     ret = ""
     if with_full_name:
         ret += message.DESCRIPTOR.full_name + "\n"
-    ret += MessageToJson(message=message, including_default_value_fields=True, preserving_proto_field_name=True, indent=4)
+
+    protobuf_major_version = int(protobuf_version.split(sep=".", maxsplit=1)[0])
+    if protobuf_major_version < 5:
+        ret += MessageToJson(message=message, including_default_value_fields=True, preserving_proto_field_name=True, indent=4)
+    else:
+        ret += MessageToJson(message=message, always_print_fields_with_no_presence=True, preserving_proto_field_name=True, indent=4)
     return ret


### PR DESCRIPTION
Impact on pyspeos due to a breaking change in google.protobuf.json_format.MessageToJson method between 4.x and 5.x
The parameter including_default_value_fields is removed and another is created : always_print_fields_with_no_presence

Both 4.x and 5.x are now handled