### PR TITLE
Script layer - Project - fix create_root_part method when a root part is already created in the project

### DIFF
--- a/src/ansys/speos/script/project.py
+++ b/src/ansys/speos/script/project.py
@@ -245,7 +245,7 @@ class Project:
             Part feature.
         """
         name = "RootPart"
-        existing_rp = self.find(name=name, feature_type=part.Part)
+        existing_rp = self.find(name="", feature_type=part.Part)
         if existing_rp != []:
             return existing_rp[0]
 

--- a/tests/script_tests/test_Project.py
+++ b/tests/script_tests/test_Project.py
@@ -257,6 +257,23 @@ def test_find_after_load(speos: Speos):
     assert sim_feats[0]._name == "ASSEMBLY1.DS (0)"
 
 
+def test_create_root_part_after_load(speos: Speos):
+    """Test create_root_part feature in project loaded from speos file."""
+
+    # Create a project from a file
+    p = script.Project(speos=speos, path=os.path.join(test_path, "LG_50M_Colorimetric_short.sv5", "LG_50M_Colorimetric_short.sv5"))
+
+    # Retrieve existing root part feature
+    # assert p.find(name="", feature_type=script.Part) is p.create_root_part()
+    rp = p.find(name="", feature_type=script.Part)[0]
+
+    # Try to create root part (but it is already existing) -> the existing root part is returned
+    rp2 = p.create_root_part()
+
+    # Check object identity
+    assert rp is rp2
+
+
 def test_delete(speos: Speos):
     """Test delete a project."""
 


### PR DESCRIPTION
Issue location:
Script layer  -  Project feature  -  create_root_part method

Issue description:
If a project contains already a root part, and the client calls create_root_part method, the root part feature is not returned but a new one is created instead.

Expected behavior:
The existing root part feature should be returned.

- [x] New test added