### PR TITLE
refactor: improve python integration by using magick method and properties

### DIFF
--- a/doc/source/cheat_sheet/cheat_sheet_script.qmd
+++ b/doc/source/cheat_sheet/cheat_sheet_script.qmd
@@ -177,9 +177,9 @@ root_part.commit()
 body_1 = root_part.create_body(name='TheBodyB1')
 body_1.commit()
 body_1_face_1 = body_1.create_face(name='TheFaceF1')
-body_1_face_1.set_vertices([])
-body_1_face_1.set_facets([])
-body_1_face_1.set_normals([])
+body_1_face_1.vertices = []
+body_1_face_1.facets = []
+body_1_face_1.normals = []
 body_1_face_1.commit()
 ```
 

--- a/examples/core-modify-scene.py
+++ b/examples/core-modify-scene.py
@@ -62,7 +62,7 @@ print(my_scene)
 # +
 for sensor_i in my_scene.get().sensors:
     print(sensor_i)  # Print instance data model
-    print(speos.client.get_item(key=sensor_i.sensor_guid))  # Print template data model
+    print(speos.client[sensor_i.sensor_guid])  # Print template data model
     print("\n")
 # -
 
@@ -72,7 +72,7 @@ for sensor_i in my_scene.get().sensors:
 for sensor_i in my_scene.get().sensors:
     if sensor_i.HasField("camera_properties"):
         print(sensor_i)  # Print instance data model
-        print(speos.client.get_item(key=sensor_i.sensor_guid))  # Print template data model
+        print(speos.client[sensor_i.sensor_guid])  # Print template data model
         print("\n")
 # -
 
@@ -104,7 +104,7 @@ print(my_scene.get().sensors[0])  # Do another get() to check new value on datab
 new_distortion_file = os.path.join(tests_data_path, os.path.join("CameraInputFiles", "CameraDistortion_150deg.OPTDistortion"))
 
 # Retrieve SensorTemplateLink corresponding to camera_i_0.sensor_guid
-camera_t_0 = speos.client.get_item(camera_i_0.sensor_guid)
+camera_t_0 = speos.client[camera_i_0.sensor_guid]
 assert isinstance(camera_t_0, core.SensorTemplateLink)
 
 # get() = retrieve datamodel corresponding to camera_t_0 from database

--- a/examples/script-part.py
+++ b/examples/script-part.py
@@ -61,13 +61,12 @@ print(root_part)
 # Each triangle/facet is defined by vertices and vertice normals.
 
 # +
-face_b1_f1 = (
-    body_b1.create_face(name="TheFaceF1")
-    .set_vertices([0, 0, 0, 1, 0, 0, 0, 1, 0])
-    .set_facets([0, 1, 2])
-    .set_normals([0, 0, 1, 0, 0, 1, 0, 0, 1])
-    .commit()
-)
+face_b1_f1 = body_b1.create_face(name="TheFaceF1")
+face_b1_f1.vertices = [0, 0, 0, 1, 0, 0, 0, 1, 0]
+face_b1_f1.facets = [0, 1, 2]
+face_b1_f1.normals = [0, 0, 1, 0, 0, 1, 0, 0, 1]
+face_b1_f1.commit()
+
 print(root_part)
 # -
 
@@ -86,13 +85,11 @@ print(root_part)
 
 body_sp1_b1 = sub_part1.create_body(name="TheBodySP1_B1").commit()
 print(root_part)
-face_sp1_b1_f1 = (
-    body_sp1_b1.create_face(name="TheFaceSP1_B1_F1")
-    .set_vertices([0, 1, 0, 0, 2, 0, 1, 2, 0])
-    .set_facets([0, 1, 2])
-    .set_normals([0, 0, 1, 0, 0, 1, 0, 0, 1])
-    .commit()
-)
+face_sp1_b1_f1 = body_sp1_b1.create_face(name="TheFaceSP1_B1_F1")
+face_sp1_b1_f1.vertices = [0, 1, 0, 0, 2, 0, 1, 2, 0]
+face_sp1_b1_f1.facets = [0, 1, 2]
+face_sp1_b1_f1.normals = [0, 0, 1, 0, 0, 1, 0, 0, 1]
+face_sp1_b1_f1.commit()
 print(root_part)
 # -
 

--- a/examples/script-simulation.py
+++ b/examples/script-simulation.py
@@ -43,9 +43,11 @@ print(p)
 
 # +
 root_part = p.create_root_part()
-root_part.create_body(name="Body.1").create_face(name="Face.1").set_vertices([0, 1, 2, 0, 2, 2, 1, 2, 2]).set_facets([0, 1, 2]).set_normals(
-    [0, 0, 1, 0, 0, 1, 0, 0, 1]
-)
+body = root_part.create_body(name="Body.1")
+face = body.create_face(name="Face.1")
+face.vertices = [0, 1, 2, 0, 2, 2, 1, 2, 2]
+face.facets = [0, 1, 2]
+face.normals = [0, 0, 1, 0, 0, 1, 0, 0, 1]
 root_part.commit()
 # -
 

--- a/src/ansys/speos/core/client.py
+++ b/src/ansys/speos/core/client.py
@@ -290,7 +290,7 @@ class SpeosClient:
             self._jobDB = JobStub(self._channel)
         return self._jobDB
 
-    def __get_item__(
+    def __getitem__(
         self, key: str
     ) -> Union[
         SOPTemplateLink,

--- a/src/ansys/speos/core/client.py
+++ b/src/ansys/speos/core/client.py
@@ -290,7 +290,7 @@ class SpeosClient:
             self._jobDB = JobStub(self._channel)
         return self._jobDB
 
-    def get_item(
+    def __get_item__(
         self, key: str
     ) -> Union[
         SOPTemplateLink,

--- a/src/ansys/speos/script/face.py
+++ b/src/ansys/speos/script/face.py
@@ -72,7 +72,13 @@ class Face:
         # Create local Face
         self._face = core.Face(name=name, description=description, metadata=metadata)
 
-    def set_vertices(self, values: List[float]) -> Face:
+    @property
+    def vertices(self):
+        res = self.face_link.get().vertices
+        return res
+
+    @vertices.setter
+    def vertices(self, values: List[float]) -> Face:
         """Set the face vertices.
 
         Parameters
@@ -88,7 +94,13 @@ class Face:
         self._face.vertices[:] = values
         return self
 
-    def set_facets(self, values: List[int]) -> Face:
+    @property
+    def facets(self):
+        res = self.face_link.get().facets
+        return res
+
+    @facets.setter
+    def facets(self, values: List[int]) -> Face:
         """Set the facets.
 
         Parameters
@@ -104,7 +116,13 @@ class Face:
         self._face.facets[:] = values
         return self
 
-    def set_normals(self, values: List[float]) -> Face:
+    @property
+    def normals(self):
+        res = self.face_link.get().normals
+        return res
+
+    @normals.setter
+    def normals(self, values: List[float]) -> Face:
         """Set the face normals.
 
         Parameters

--- a/src/ansys/speos/script/intensity.py
+++ b/src/ansys/speos/script/intensity.py
@@ -292,7 +292,7 @@ class Intensity:
             self.set_cos(N=1)  # By default will be lambertian (cos with N =1)
         else:
             # Retrieve IntensityTemplate
-            self.intensity_template_link = speos_client.get_item(key=key)
+            self.intensity_template_link = speos_client[key]
             self._intensity_template = self.intensity_template_link.get()
 
     def set_library(self) -> Intensity.Library:

--- a/src/ansys/speos/script/opt_prop.py
+++ b/src/ansys/speos/script/opt_prop.py
@@ -413,9 +413,9 @@ class OptProp:
     def _fill(self, mat_inst):
         self._unique_id = mat_inst.metadata["UniqueId"]
         self._material_instance = mat_inst
-        self.vop_template_link = self._project.client.get_item(key=mat_inst.vop_guid)
+        self.vop_template_link = self._project.client[mat_inst.vop_guid]
         if len(mat_inst.sop_guids) > 0:
-            self.sop_template_link = self._project.client.get_item(key=mat_inst.sop_guids[0])
+            self.sop_template_link = self._project.client[mat_inst.sop_guids[0]]
         else:  # Specific case for ambient material
             self._sop_template = None
         self.reset()

--- a/src/ansys/speos/script/project.py
+++ b/src/ansys/speos/script/project.py
@@ -493,7 +493,7 @@ class Project:
     def _add_unique_ids(self):
         scene_data = self.scene_link.get()
 
-        root_part_link = self.client.get_item(key=scene_data.part_guid)
+        root_part_link = self.client[scene_data.part_guid]
         root_part = root_part_link.get()
         update_rp = False
         for sub_part in root_part.parts:
@@ -527,7 +527,7 @@ class Project:
 
         scene_data = self.scene_link.get()
 
-        root_part_link = self.client.get_item(key=scene_data.part_guid)
+        root_part_link = self.client[scene_data.part_guid]
         root_part_data = root_part_link.get()
         root_part_feats = self.find(name="", feature_type=part.Part)
         root_part_feat = None
@@ -547,7 +547,7 @@ class Project:
             if sp.description.startswith("UniqueId_"):
                 idx = sp.description.find("_")
                 sp_feat._unique_id = sp.description[idx + 1 :]
-            sp_feat.part_link = self.client.get_item(key=sp.part_guid)
+            sp_feat.part_link = self.client[sp.part_guid]
             part_data = sp_feat.part_link.get()
             sp_feat._part_instance = sp
             sp_feat._part = part_data  # instead of sp_feat.reset() - this avoid a useless read in server
@@ -577,7 +577,7 @@ class Project:
             self._features.append(ssr_feat)
 
         for sim_inst in scene_data.simulations:
-            simulation_template_link = self.client.get_item(key=sim_inst.simulation_guid).get()
+            simulation_template_link = self.client[sim_inst.simulation_guid].get()
             if simulation_template_link.HasField("direct_mc_simulation_template"):
                 sim_feat = simulation.Direct(project=self, name=sim_inst.name, simulation_instance=sim_inst, default_values=False)
             elif simulation_template_link.HasField("inverse_mc_simulation_template"):
@@ -631,9 +631,9 @@ class Project:
             part_coordinate = part_coordinate_info
         part_mesh_info = None
         for body_idx, body_guid in enumerate(part_data.body_guids):
-            body_item_data = self.client.get_item(body_guid).get()
+            body_item_data = self.client[body_guid].get()
             for face_idx, face_guid in enumerate(body_item_data.face_guids):
-                face_item_data = self.client.get_item(face_guid).get()
+                face_item_data = self.client[face_guid].get()
                 vertices = np.array(face_item_data.vertices)
                 facets = np.array(face_item_data.facets)
                 vertices = vertices.reshape(-1, 3)
@@ -668,12 +668,12 @@ class Project:
             viz_args = {}
         _preview_mesh = pv.PolyData()
         # Retrieve root part
-        root_part_data = self.client.get_item(self.scene_link.get().part_guid).get()
+        root_part_data = self.client[self.scene_link.get().part_guid].get()
 
         # Loop on all sub parts to retrieve their mesh
         if len(root_part_data.parts) != 0:
             for part_idx, part_item in enumerate(root_part_data.parts):
-                part_item_data = self.client.get_item(part_item.part_guid).get()
+                part_item_data = self.client[part_item.part_guid].get()
                 poly_data = self.__extract_part_mesh_info(part_data=part_item_data, part_coordinate_info=part_item.axis_system)
                 if poly_data is not None:
                     _preview_mesh = _preview_mesh.append_polydata(poly_data)

--- a/src/ansys/speos/script/proto_message_utils.py
+++ b/src/ansys/speos/script/proto_message_utils.py
@@ -58,7 +58,7 @@ def _replace_guid_elt(speos_client: SpeosClient, json_dict: dict, ignore_simple_
         # If we are in the case of key "xxx_guid", with a guid non empty and that the key is not to ignore
         if k.endswith("_guid") and v != "" and k != ignore_simple_key:
             # Retrieve the item from db and transform it to dictionary
-            new_v = protobuf_message_to_dict(message=speos_client.get_item(key=v).get())
+            new_v = protobuf_message_to_dict(message=speos_client[v].get())
 
             # This item can potentially have some "xxx_guid" fields to replace
             _replace_guid_elt(speos_client=speos_client, json_dict=new_v, ignore_simple_key=ignore_simple_key)
@@ -71,7 +71,7 @@ def _replace_guid_elt(speos_client: SpeosClient, json_dict: dict, ignore_simple_
             new_value_list = []
             for iv in v:
                 # Retrieve the item from db and transform it to dictionary
-                new_v = protobuf_message_to_dict(message=speos_client.get_item(key=iv).get())
+                new_v = protobuf_message_to_dict(message=speos_client[iv].get())
 
                 # This item can potentially have some "xxx_guid" fields to replace
                 _replace_guid_elt(speos_client=speos_client, json_dict=new_v, ignore_simple_key=ignore_simple_key)

--- a/src/ansys/speos/script/sensor.py
+++ b/src/ansys/speos/script/sensor.py
@@ -85,7 +85,7 @@ class BaseSensor:
             self._sensor_instance = core.Scene.SensorInstance(name=name, description=description, metadata=metadata)
         else:
             self._unique_id = sensor_instance.metadata["UniqueId"]
-            self.sensor_template_link = self._project.client.get_item(key=sensor_instance.sensor_guid)
+            self.sensor_template_link = self._project.client[sensor_instance.sensor_guid]
             # reset will fill _sensor_instance and _sensor_template from respectively project (using _unique_id) and sensor_template_link
             self.reset()
 

--- a/src/ansys/speos/script/simulation.py
+++ b/src/ansys/speos/script/simulation.py
@@ -136,7 +136,7 @@ class BaseSimulation:
             self._simulation_instance = core.Scene.SimulationInstance(name=name, description=description, metadata=metadata)
         else:
             self._unique_id = simulation_instance.metadata["UniqueId"]
-            self.simulation_template_link = self._project.client.get_item(key=simulation_instance.simulation_guid)
+            self.simulation_template_link = self._project.client[simulation_instance.simulation_guid]
             self.reset()
 
         # Create local Job
@@ -433,7 +433,7 @@ class BaseSimulation:
     def _fill(self, sim_inst):
         self._unique_id = sim_inst.metadata["UniqueId"]
         self._simulation_instance = sim_inst
-        self.simulation_template_link = self._project.client.get_item(key=sim_inst.simulation_guid)
+        self.simulation_template_link = self._project.client[sim_inst.simulation_guid]
         self.reset()
 
 

--- a/src/ansys/speos/script/source.py
+++ b/src/ansys/speos/script/source.py
@@ -84,7 +84,7 @@ class BaseSource:
             self._source_instance = core.Scene.SourceInstance(name=name, description=description, metadata=metadata)
         else:
             self._unique_id = source_instance.metadata["UniqueId"]
-            self.source_template_link = self._project.client.get_item(key=source_instance.source_guid)
+            self.source_template_link = self._project.client[source_instance.source_guid]
             self._reset()
 
     class _Spectrum:
@@ -292,7 +292,7 @@ class BaseSource:
     def _fill(self, src_inst):
         self._unique_id = src_inst.metadata["UniqueId"]
         self._source_instance = src_inst
-        self.source_template_link = self._project.client.get_item(key=src_inst.source_guid)
+        self.source_template_link = self._project.client[src_inst.source_guid]
         self._reset()
 
     def commit(self) -> BaseSource:

--- a/src/ansys/speos/script/spectrum.py
+++ b/src/ansys/speos/script/spectrum.py
@@ -69,7 +69,7 @@ class Spectrum:
             self.set_monochromatic()  # By default will be monochromatic
         else:
             # Retrieve Spectrum
-            self.spectrum_link = speos_client.get_item(key=key)
+            self.spectrum_link = speos_client[key]
             self._spectrum = self.spectrum_link.get()
 
     def set_monochromatic(self, wavelength: float = 555.0) -> Spectrum:

--- a/src/ansys/speos/workflow/combine_speos.py
+++ b/src/ansys/speos/workflow/combine_speos.py
@@ -73,7 +73,7 @@ def insert_speos(project: Project, speos_to_insert: List[SpeosFileInstance]) -> 
     if project.scene_link.get().part_guid == "":
         part_link = project.client.parts().create(message=Part())
     else:
-        part_link = project.client.get_item(project.scene_link.get().part_guid)
+        part_link = project.client[project.scene_link.get().part_guid]
 
     # Combine all speos_to_insert into the project
     _combine(project=project, part_link=part_link, speos_to_combine=speos_to_insert)

--- a/tests/core_tests/test_geometry.py
+++ b/tests/core_tests/test_geometry.py
@@ -173,7 +173,7 @@ def test_body(speos: Speos):
     faces_to_delete = body0.get().face_guids
     body0.delete()
     for face_key in faces_to_delete:
-        face = speos.client.get_item(key=face_key)
+        face = speos.client[face_key]
         assert isinstance(face, FaceLink)
         face.delete()
 
@@ -212,10 +212,10 @@ def test_part(speos: Speos):
     assert part1.key != ""
 
     for body_key in part1.get().body_guids:
-        body = speos.client.get_item(key=body_key)
+        body = speos.client[body_key]
         assert isinstance(body, BodyLink)
         for face_key in body.get().face_guids:
-            face = speos.client.get_item(key=face_key)
+            face = speos.client[face_key]
             assert isinstance(face, FaceLink)
             face.delete()
         body.delete()

--- a/tests/script_tests/test_Part.py
+++ b/tests/script_tests/test_Part.py
@@ -239,7 +239,7 @@ def test_commit_part(speos: Speos):
     assert root_part.part_link is not None
     assert p.scene_link.get().part_guid == root_part.part_link.key
     assert len(root_part.part_link.get().parts) == 1
-    assert len(speos.client.get_item(key=root_part.part_link.get().parts[0].part_guid).get().parts) == 1
+    assert len(speos.client[root_part.part_link.get().parts[0].part_guid].get().parts) == 1
     assert len(root_part.part_link.get().body_guids) == 1
 
     # Change only in local not committed

--- a/tests/script_tests/test_Part.py
+++ b/tests/script_tests/test_Part.py
@@ -84,15 +84,13 @@ def test_create_face(speos: Speos):
     assert len(body1.body_link.get().face_guids) == 0
 
     # Add a face
-    face1 = (
-        body1.create_face(name="Face.1")
-        .set_vertices([0, 1, 0, 0, 2, 0, 1, 2, 0])
-        .set_facets([0, 1, 2])
-        .set_normals([0, 0, 1, 0, 0, 1, 0, 0, 1])
-        .commit()
-    )
-    assert len(body1._geom_features) == 1
+    face1 = body1.create_face(name="Face.1")
+    face1.vertices = [0, 1, 0, 0, 2, 0, 1, 2, 0]
+    face1.facets = [0, 1, 2]
+    face1.normals = [0, 0, 1, 0, 0, 1, 0, 0, 1]
+    face1.commit()
 
+    assert len(body1._geom_features) == 1
     assert len(body1.body_link.get().face_guids) == 1
     assert body1.body_link.get().face_guids[0] == face1.face_link.key
     assert face1.face_link.get().vertices == [0, 1, 0, 0, 2, 0, 1, 2, 0]
@@ -100,15 +98,13 @@ def test_create_face(speos: Speos):
     assert face1.face_link.get().normals == [0, 0, 1, 0, 0, 1, 0, 0, 1]
 
     # Add another face + commit on root part
-    face2 = (
-        body1.create_face(name="Face.2")
-        .set_vertices([0, 0, 0, 1, 0, 0, 0, 1, 0])
-        .set_facets([0, 2, 1])
-        .set_normals([0, 0, 1, 0, 0, 1, 0, 0, 1])
-        .commit()
-    )
-    assert len(body1._geom_features) == 2
+    face2 = body1.create_face(name="Face.2")
+    face2.vertices = [0, 0, 0, 1, 0, 0, 0, 1, 0]
+    face2.facets = [0, 2, 1]
+    face2.normals = [0, 0, 1, 0, 0, 1, 0, 0, 1]
+    face2.commit()
 
+    assert len(body1._geom_features) == 2
     assert len(body1.body_link.get().face_guids) == 2
     assert body1.body_link.get().face_guids[1] == face2.face_link.key
     assert face2.face_link.get().vertices == [0, 0, 0, 1, 0, 0, 0, 1, 0]

--- a/tests/script_tests/test_Project.py
+++ b/tests/script_tests/test_Project.py
@@ -321,8 +321,8 @@ def test_from_file(speos: Speos):
 
     # And that the feature retrieved has a real impact on the project
     feat_ops[0].set_surface_mirror(reflectance=60).commit()
-    assert speos.client.get_item(key=p.scene_link.get().materials[2].sop_guids[0]).get().HasField("mirror")
-    assert speos.client.get_item(key=p.scene_link.get().materials[2].sop_guids[0]).get().mirror.reflectance == 60
+    assert speos.client[p.scene_link.get().materials[2].sop_guids[0]].get().HasField("mirror")
+    assert speos.client[p.scene_link.get().materials[2].sop_guids[0]].get().mirror.reflectance == 60
 
     # Check that ambient mat has no sop
     feat_op_ambients = p.find(name=p.scene_link.get().materials[-1].name)
@@ -337,7 +337,7 @@ def test_from_file(speos: Speos):
     # And that we can modify it (and that other values are not overridden by default values)
     feat_ssrs[0].set_type_colorimetric().set_wavelengths_range().set_end(value=800)
     feat_ssrs[0].commit()
-    ssr_link = speos.client.get_item(key=p.scene_link.get().sensors[0].sensor_guid)
+    ssr_link = speos.client[p.scene_link.get().sensors[0].sensor_guid]
     ssr_data = ssr_link.get()
     assert ssr_data.HasField("irradiance_sensor_template")
     assert ssr_data.irradiance_sensor_template.HasField("sensor_type_colorimetric")
@@ -355,21 +355,21 @@ def test_find_geom(speos: Speos):
     assert p.scene_link.get().part_guid != ""
 
     # Check that RootPart feature can be retrieved
-    part_data = speos.client.get_item(p.scene_link.get().part_guid).get()
+    part_data = speos.client[p.scene_link.get().part_guid].get()
     feat_rps = p.find(name="", feature_type=script.Part)
     assert len(feat_rps) == 1
     assert type(feat_rps[0]) is script.Part
 
     # Check that body can be retrieved
     assert len(part_data.body_guids) == 3
-    body1_data = speos.client.get_item(part_data.body_guids[1]).get()
+    body1_data = speos.client[part_data.body_guids[1]].get()
     feat_bodies = p.find(name=body1_data.name, feature_type=script.Part)
     assert len(feat_bodies) == 1
     assert type(feat_bodies[0]) is script.Body
 
     # Check that face can be retrieved
     assert len(body1_data.face_guids) > 4
-    face2_data = speos.client.get_item(body1_data.face_guids[2]).get()
+    face2_data = speos.client[body1_data.face_guids[2]].get()
     feat_faces = p.find(name=body1_data.name + "/" + face2_data.name, feature_type=script.Part)
     assert len(feat_faces) == 1
     assert type(feat_faces[0]) is script.Face

--- a/tests/script_tests/test_Simulation.py
+++ b/tests/script_tests/test_Simulation.py
@@ -334,9 +334,10 @@ def test_commit(speos: Speos):
 
     # Prerequisites: a source and a sensor are needed (bug also a rootpart and optical property)
     root_part = p.create_root_part()
-    root_part.create_body(name="Body.1").create_face(name="Face.1").set_vertices([0, 1, 0, 0, 2, 0, 1, 2, 0]).set_facets(
-        [0, 1, 2]
-    ).set_normals([0, 0, 1, 0, 0, 1, 0, 0, 1])
+    face = root_part.create_body(name="Body.1").create_face(name="Face.1")
+    face.vertices = [0, 1, 0, 0, 2, 0, 1, 2, 0]
+    face.facets = [0, 1, 2]
+    face.normals = [0, 0, 1, 0, 0, 1, 0, 0, 1]
     root_part.commit()
 
     opt_prop = p.create_optical_property(name="Material.1")
@@ -388,9 +389,10 @@ def test_reset(speos: Speos):
 
     # Prerequisites: a source and a sensor are needed (bug also a rootpart and optical property)
     root_part = p.create_root_part()
-    root_part.create_body(name="Body.1").create_face(name="Face.1").set_vertices([0, 1, 0, 0, 2, 0, 1, 2, 0]).set_facets(
-        [0, 1, 2]
-    ).set_normals([0, 0, 1, 0, 0, 1, 0, 0, 1])
+    face = root_part.create_body(name="Body.1").create_face(name="Face.1")
+    face.vertices = [0, 1, 0, 0, 2, 0, 1, 2, 0]
+    face.facets = [0, 1, 2]
+    face.normals = [0, 0, 1, 0, 0, 1, 0, 0, 1]
     root_part.commit()
 
     opt_prop = p.create_optical_property(name="Material.1")
@@ -440,9 +442,10 @@ def test_direct_modify_after_reset(speos: Speos):
 
     # Prerequisites: a source and a sensor are needed (bug also a rootpart and optical property)
     root_part = p.create_root_part()
-    root_part.create_body(name="Body.1").create_face(name="Face.1").set_vertices([0, 1, 0, 0, 2, 0, 1, 2, 0]).set_facets(
-        [0, 1, 2]
-    ).set_normals([0, 0, 1, 0, 0, 1, 0, 0, 1])
+    face = root_part.create_body(name="Body.1").create_face(name="Face.1")
+    face.vertices = [0, 1, 0, 0, 2, 0, 1, 2, 0]
+    face.facets = [0, 1, 2]
+    face.normals = [0, 0, 1, 0, 0, 1, 0, 0, 1]
     root_part.commit()
 
     opt_prop = p.create_optical_property(name="Material.1")
@@ -494,9 +497,10 @@ def test_inverse_modify_after_reset(speos: Speos):
 
     # Prerequisites: a source and a sensor are needed (bug also a rootpart and optical property)
     root_part = p.create_root_part()
-    root_part.create_body(name="Body.1").create_face(name="Face.1").set_vertices([0, 1, 0, 0, 2, 0, 1, 2, 0]).set_facets(
-        [0, 1, 2]
-    ).set_normals([0, 0, 1, 0, 0, 1, 0, 0, 1])
+    face = root_part.create_body(name="Body.1").create_face(name="Face.1")
+    face.vertices = [0, 1, 0, 0, 2, 0, 1, 2, 0]
+    face.facets = [0, 1, 2]
+    face.normals = [0, 0, 1, 0, 0, 1, 0, 0, 1]
     root_part.commit()
 
     opt_prop = p.create_optical_property(name="Material.1")
@@ -548,9 +552,10 @@ def test_interactive_modify_after_reset(speos: Speos):
 
     # Prerequisites: a source and a sensor are needed (bug also a rootpart and optical property)
     root_part = p.create_root_part()
-    root_part.create_body(name="Body.1").create_face(name="Face.1").set_vertices([0, 1, 0, 0, 2, 0, 1, 2, 0]).set_facets(
-        [0, 1, 2]
-    ).set_normals([0, 0, 1, 0, 0, 1, 0, 0, 1])
+    face = root_part.create_body(name="Body.1").create_face(name="Face.1")
+    face.vertices = [0, 1, 0, 0, 2, 0, 1, 2, 0]
+    face.facets = [0, 1, 2]
+    face.normals = [0, 0, 1, 0, 0, 1, 0, 0, 1]
     root_part.commit()
 
     opt_prop = p.create_optical_property(name="Material.1")
@@ -602,9 +607,10 @@ def test_delete(speos: Speos):
 
     # Prerequisites: a source and a sensor are needed (bug also a rootpart and optical property)
     root_part = p.create_root_part()
-    root_part.create_body(name="Body.1").create_face(name="Face.1").set_vertices([0, 1, 0, 0, 2, 0, 1, 2, 0]).set_facets(
-        [0, 1, 2]
-    ).set_normals([0, 0, 1, 0, 0, 1, 0, 0, 1])
+    face = root_part.create_body(name="Body.1").create_face(name="Face.1")
+    face.vertices = [0, 1, 0, 0, 2, 0, 1, 2, 0]
+    face.facets = [0, 1, 2]
+    face.normals = [0, 0, 1, 0, 0, 1, 0, 0, 1]
     root_part.commit()
 
     opt_prop = p.create_optical_property(name="Material.1")

--- a/tests/script_tests/test_Source.py
+++ b/tests/script_tests/test_Source.py
@@ -56,7 +56,7 @@ def test_create_luminaire_source(speos: Speos):
     # spectrum
     source1.set_spectrum().set_halogen()
     source1.commit()
-    spectrum = speos.client.get_item(key=source1.source_template_link.get().luminaire.spectrum_guid)
+    spectrum = speos.client[source1.source_template_link.get().luminaire.spectrum_guid]
     assert spectrum.get().HasField("predefined")
     assert spectrum.get().predefined.HasField("halogen")
 
@@ -105,11 +105,11 @@ def test_create_surface_source(speos: Speos):
     assert source1.source_template_link.get().surface.HasField("luminous_flux")
     assert source1.source_template_link.get().surface.luminous_flux.luminous_value == 683
     assert source1.source_template_link.get().surface.HasField("spectrum_guid")
-    spectrum = speos.client.get_item(key=source1.source_template_link.get().surface.spectrum_guid)
+    spectrum = speos.client[source1.source_template_link.get().surface.spectrum_guid]
     assert spectrum.get().name == "Surface.1.Spectrum"
     assert spectrum.get().HasField("monochromatic")
     assert source1.source_template_link.get().surface.intensity_guid != ""
-    intensity = speos.client.get_item(key=source1.source_template_link.get().surface.intensity_guid)
+    intensity = speos.client[source1.source_template_link.get().surface.intensity_guid]
     assert intensity.get().HasField("cos")
 
     # set intensity as library to be able to use flux_from_intensity_file
@@ -117,7 +117,7 @@ def test_create_surface_source(speos: Speos):
     source1.set_flux_from_intensity_file()
     source1.commit()
     assert source1.source_template_link.get().surface.HasField("flux_from_intensity_file")
-    intensity = speos.client.get_item(key=source1.source_template_link.get().surface.intensity_guid)
+    intensity = speos.client[source1.source_template_link.get().surface.intensity_guid]
     assert intensity.get().HasField("library")
     assert source1._source_instance.HasField("surface_properties")
     assert source1._source_instance.surface_properties.HasField("intensity_properties")
@@ -226,7 +226,7 @@ def test_create_rayfile_source(speos: Speos):
     source1.set_spectrum().set_blackbody()
     source1.commit()
     assert source1.source_template_link.get().rayfile.spectrum_guid != ""
-    spectrum = speos.client.get_item(key=source1.source_template_link.get().rayfile.spectrum_guid)
+    spectrum = speos.client[source1.source_template_link.get().rayfile.spectrum_guid]
     assert spectrum.get().name == "Ray-file.1.Spectrum"
     assert spectrum.get().HasField("blackbody")
 


### PR DESCRIPTION
This PR is currently a WIP. The changes are:
- using `__getitem__` instead of the `get_item` method that was implemented. The great thing with that change is that any use can now call `speos_client[my_key]` instead of `speos_client.get_item(key=my_key)`. It's a good practice to implement magick methods when they make sense.
- using Python `property` to propose something simple to our users while hidding the complexity. This way, a user will think he is playing with an attribute when, behind the scene, there is something complexe going on. It is also a good practice in Python.

> [!NOTE]  
I used `property` for the `Face` class, if the change is accepted, we can think about applying it to all `script` files

