### PR TITLE
fix: core layer loading a camera sensor

### DIFF
--- a/doc/changelog.d/503.fixed.md
+++ b/doc/changelog.d/503.fixed.md
@@ -1,0 +1,1 @@
+core layer loading a camera sensor

--- a/src/ansys/speos/core/project.py
+++ b/src/ansys/speos/core/project.py
@@ -678,11 +678,11 @@ class Project:
                 ssr_feat = SensorIrradiance(
                     project=self, name=ssr_inst.name, sensor_instance=ssr_inst, default_values=False
                 )
-            elif ssr_inst.HasField("camera_properties"):
+            elif ssr_inst.HasField("radiance_properties"):
                 ssr_feat = SensorRadiance(
                     project=self, name=ssr_inst.name, sensor_instance=ssr_inst, default_values=False
                 )
-            elif ssr_inst.HasField("radiance_properties"):
+            elif ssr_inst.HasField("camera_properties"):
                 ssr_feat = SensorCamera(
                     project=self, name=ssr_inst.name, sensor_instance=ssr_inst, default_values=False
                 )


### PR DESCRIPTION
## Description
**In the Core layer, when loading a speos file which contains camera sensor, a SensorRadiance type is created rather than SensorCamera.**

## Issue linked
**502**

## Checklist
- [x] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
