### PR TITLE
docs: add example assets button

### DIFF
--- a/doc/source/_static/assets/download/.gitignore
+++ b/doc/source/_static/assets/download/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/doc/source/_static/assets/download/README.md
+++ b/doc/source/_static/assets/download/README.md
@@ -1,0 +1,1 @@
+Downloadable assets are stored here.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -138,8 +138,9 @@ if BUILD_EXAMPLES:
     nbsphinx_prompt_width = ""
     nbsphinx_prolog = """
 
-    .. grid:: 3
-        :gutter: 1
+    .. grid:: 5
+
+        .. grid-item::
 
         .. grid-item::
             :child-align: center
@@ -159,12 +160,24 @@ if BUILD_EXAMPLES:
 
                 Download as Jupyter notebook :fas:`book`
 
+        .. grid-item::
+            :child-align: center
+
+            .. button-link:: {cname_pref}/{assets_loc}
+               :color: primary
+               :shadow:
+
+                Download example's assets :fa:`file`
+
+        .. grid-item::
+
 ----
 
     """.format(
         cname_pref=f"https://{cname}/version/{get_version_match(version)}",
         python_file_loc="{{ env.docname }}.py",
         ipynb_file_loc="{{ env.docname }}.ipynb",
+        assets_loc="_static/assets/download/"
     )
 
 
@@ -261,6 +274,26 @@ def copy_examples_files_to_source_dir(app: sphinx.application.Sphinx):
         destination_file.write_text(file.read_text(encoding="utf-8"), encoding="utf-8")
 
 
+def copy_assets_to_output_dir(app: sphinx.application.Sphinx, exception: Exception):
+    """Copy the assets directory to the output directory of the documentation.
+
+    Parameters
+    ----------
+    app : sphinx.application.Sphinx
+        Sphinx application instance containing the all the doc build configuration.
+    exception : Exception
+        Exception encountered during the building of the documentation.
+    """
+    SOURCE_ASSETS = pathlib.Path(app.outdir) / "_static" / "assets" / "download"
+    ASSETS_DIRECTORY = SOURCE_ASSETS.parent.parent.parent / "tests" / "assets"
+
+    logger = logging.getLogger(__name__)
+    logger.info("Extracting assets to output directory...")
+    zip_path = pathlib.Path(shutil.make_archive("assets", 'zip', ASSETS_DIRECTORY))
+    zip_path = shutil.move(zip_path, SOURCE_ASSETS / zip_path.name)
+    logger.info(f"Extracted assets to {zip_path}.")
+
+
 def remove_examples_from_source_dir(app: sphinx.application.Sphinx, exception: Exception):
     """
     Remove the example files from the documentation source directory.
@@ -297,4 +330,5 @@ def setup(app: sphinx.application.Sphinx):
     if BUILD_EXAMPLES:
         app.connect("builder-inited", copy_examples_files_to_source_dir)
         app.connect("build-finished", remove_examples_from_source_dir)
+        app.connect("build-finished", copy_assets_to_output_dir)
         app.connect("build-finished", copy_examples_to_output_dir)

--- a/examples/core/lpf-preview.py
+++ b/examples/core/lpf-preview.py
@@ -12,6 +12,8 @@ from ansys.speos.core.simulation import SimulationInteractive
 tests_data_path = Path("/app") / "assets"
 # If using local server
 # tests_data_path = Path().resolve().parent.parent / "tests" / "assets"
+# If using a different path
+# tests_data_path = Path("path/to/downloaded/example/assets")
 # -
 
 # ## Create connection with speos rpc server

--- a/examples/core/opt-prop.py
+++ b/examples/core/opt-prop.py
@@ -18,6 +18,8 @@ from ansys.speos.core import GeoRef, Project, Speos
 tests_data_path = Path("/app") / "assets"
 # If using local server
 # tests_data_path = Path().resolve().parent.parent / "tests" / "assets"
+# If using a different path
+# tests_data_path = Path("path/to/downloaded/example/assets")
 # -
 
 # ## Create connection with speos rpc server

--- a/examples/core/part.py
+++ b/examples/core/part.py
@@ -17,6 +17,8 @@ from ansys.speos.core import Body, Face, Part, Project, Speos
 tests_data_path = Path("/app") / "assets"
 # If using local server
 # tests_data_path = Path().resolve().parent.parent / "tests" / "assets"
+# If using a different path
+# tests_data_path = Path("path/to/downloaded/example/assets")
 # -
 
 # ## Create connection with speos rpc server

--- a/examples/core/prism-example.py
+++ b/examples/core/prism-example.py
@@ -14,6 +14,8 @@ from ansys.speos.core.simulation import SimulationDirect
 tests_data_path = Path("/app") / "assets"
 # If using local server
 # tests_data_path = Path().resolve().parent.parent / "tests" / "assets"
+# If using a different path
+# tests_data_path = Path("path/to/downloaded/example/assets")
 # -
 
 # ## Create connection with speos rpc server

--- a/examples/core/project.py
+++ b/examples/core/project.py
@@ -23,6 +23,8 @@ from ansys.speos.core.source import SourceSurface
 tests_data_path = Path("/app") / "assets"
 # If using local server
 # tests_data_path = Path().resolve().parent.parent / "tests" / "assets"
+# If using a different path
+# tests_data_path = Path("path/to/downloaded/example/assets")
 # -
 
 # ## Create connection with speos rpc server

--- a/examples/core/sensor.py
+++ b/examples/core/sensor.py
@@ -18,6 +18,8 @@ from ansys.speos.core.sensor import (
 tests_data_path = Path("/app") / "assets"
 # If using local server
 # tests_data_path = Path().resolve().parent.parent / "tests" / "assets"
+# If using a different path
+# tests_data_path = Path("path/to/downloaded/example/assets")
 # -
 
 # ## Create connection with speos rpc server

--- a/examples/core/simulation.py
+++ b/examples/core/simulation.py
@@ -16,6 +16,8 @@ from ansys.speos.core.simulation import SimulationInteractive, SimulationInverse
 tests_data_path = Path("/app") / "assets"
 # If using local server
 # tests_data_path = Path().resolve().parent.parent / "tests" / "assets"
+# If using a different path
+# tests_data_path = Path("path/to/downloaded/example/assets")
 # -
 
 # ## Create connection with speos rpc server

--- a/examples/core/source.py
+++ b/examples/core/source.py
@@ -18,6 +18,8 @@ from ansys.speos.core.source import (
 tests_data_path = Path("/app") / "assets"
 # If using local server
 # tests_data_path = Path().resolve().parent.parent / "tests" / "assets"
+# If using a different path
+# tests_data_path = Path("path/to/downloaded/example/assets")
 # -
 
 # ## Create connection with speos rpc server

--- a/examples/kernel/modify-scene.py
+++ b/examples/kernel/modify-scene.py
@@ -36,6 +36,8 @@ from ansys.speos.core.kernel.sensor_template import ProtoSensorTemplate
 tests_data_path = Path("/app") / "assets"
 # If using local server
 # tests_data_path = Path().resolve().parent.parent / "tests" / "assets"
+# If using a different path
+# tests_data_path = Path("path/to/downloaded/example/assets")
 # -
 
 # Create connection with speos rpc server

--- a/examples/kernel/scene-job.py
+++ b/examples/kernel/scene-job.py
@@ -14,6 +14,8 @@ from ansys.speos.core.speos import Speos
 tests_data_path = Path("/app") / "assets"
 # If using local server
 # tests_data_path = Path().resolve().parent.parent / "tests" / "assets"
+# If using a different path
+# tests_data_path = Path("path/to/downloaded/example/assets")
 # -
 
 # Create connection with speos rpc server

--- a/examples/workflow/combine-speos.py
+++ b/examples/workflow/combine-speos.py
@@ -19,6 +19,8 @@ from ansys.speos.core.workflow.combine_speos import (
 tests_data_path = Path("/app") / "assets"
 # If using local server
 # tests_data_path = Path().resolve().parent.parent / "tests" / "assets"
+# If using a different path
+# tests_data_path = Path("path/to/downloaded/example/assets")
 # -
 
 # ## Create connection with speos rpc server

--- a/examples/workflow/open-result.py
+++ b/examples/workflow/open-result.py
@@ -13,6 +13,8 @@ from ansys.speos.core.simulation import SimulationDirect
 tests_data_path = Path("/app") / "assets"
 # If using local server
 # tests_data_path = Path().resolve().parent.parent / "tests" / "assets"
+# If using a different path
+# tests_data_path = Path("path/to/downloaded/example/assets")
 # -
 
 # ## Create connection with speos rpc server

--- a/src/ansys/speos/core/sensor.py
+++ b/src/ansys/speos/core/sensor.py
@@ -1598,7 +1598,7 @@ class SensorCamera(BaseSensor):
 
     @property
     def photometric(self) -> Union[SensorCamera.Photometric, None]:
-        """Property containing the instance of Camera.Photometric used to build the sensor.
+        """Property containing the instance of SensorCamera.Photometric used to build the sensor.
 
         Returns
         -------


### PR DESCRIPTION
## Description
Adding a button to download the examples assets. I had too add a work around to ensure that the 3 download buttons were aligned somehow "correctly".  See the result below

![image](https://github.com/user-attachments/assets/58fcdb8f-21a0-4416-9b45-de895c5d4a35)

If that's fine with you, we can leave it like that for the moment as we have to test that assets are correctly uploaded and available for download through the documentation. A next step (PR) could be to remove the buttons and only use text content with hyperlinks to trigger the downloading of files.

## Issue linked
Related to #497 
Close #517 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
