### PR TITLE
docs: fix path to download assets

### DIFF
--- a/doc/changelog.d/522.documentation.md
+++ b/doc/changelog.d/522.documentation.md
@@ -1,0 +1,1 @@
+fix path to download assets

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -178,7 +178,7 @@ if BUILD_EXAMPLES:
         cname_pref=f"https://{cname}/version/{get_version_match(version)}",
         python_file_loc="{{ env.docname }}.py",
         ipynb_file_loc="{{ env.docname }}.ipynb",
-        assets_loc="_static/assets/download/",
+        assets_loc="_static/assets/download/assets.zip",
     )
 
 


### PR DESCRIPTION
## Description
As title says. The current click on "download assets" ends in 404 not found page because the path was not correctly set.
However, adding "assets.zip" to the URL fixes this :)

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
