### PR TITLE
fix: unittest update based on bug 1229712

### DIFF
--- a/doc/changelog.d/579.fixed.md
+++ b/doc/changelog.d/579.fixed.md
@@ -1,0 +1,1 @@
+unittest update based on bug 1229712

--- a/tests/core/test_sensor.py
+++ b/tests/core/test_sensor.py
@@ -163,6 +163,15 @@ def test_create_camera_sensor(speos: Speos):
 
     # sensor_mode_photometric
     sensor1.set_mode_photometric()
+    sensor1.set_mode_photometric().set_mode_color().set_red_spectrum_file_uri(
+        uri=str(Path(test_path) / "CameraInputFiles" / "CameraSensitivityRed.spectrum")
+    )
+    sensor1.set_mode_photometric().set_mode_color().set_green_spectrum_file_uri(
+        uri=str(Path(test_path) / "CameraInputFiles" / "CameraSensitivityGreen.spectrum")
+    )
+    sensor1.set_mode_photometric().set_mode_color().set_blue_spectrum_file_uri(
+        uri=str(Path(test_path) / "CameraInputFiles" / "CameraSensitivityBlue.spectrum")
+    )
     sensor1.commit()
     camera_sensor_template = sensor1.sensor_template_link.get().camera_sensor_template
     assert camera_sensor_template.HasField("sensor_mode_photometric")
@@ -237,39 +246,29 @@ def test_create_camera_sensor(speos: Speos):
 
     # color_mode_color
     sensor1.set_mode_photometric().set_mode_color()
-    sensor1.commit()
-    camera_sensor_template = sensor1.sensor_template_link.get().camera_sensor_template
-    assert camera_sensor_template.sensor_mode_photometric.HasField("color_mode_color")
-
     # red_spectrum_file_uri
     sensor1.set_mode_photometric().set_mode_color().set_red_spectrum_file_uri(
         uri=str(Path(test_path) / "CameraInputFiles" / "CameraSensitivityRed.spectrum")
     )
-    sensor1.commit()
-    camera_sensor_template = sensor1.sensor_template_link.get().camera_sensor_template
-    mode_photometric = camera_sensor_template.sensor_mode_photometric
-    assert mode_photometric.color_mode_color.red_spectrum_file_uri.endswith(
-        "CameraSensitivityRed.spectrum"
-    )
-
     # green_spectrum_file_uri
     sensor1.set_mode_photometric().set_mode_color().set_green_spectrum_file_uri(
         uri=str(Path(test_path) / "CameraInputFiles" / "CameraSensitivityGreen.spectrum")
     )
-    sensor1.commit()
-    camera_sensor_template = sensor1.sensor_template_link.get().camera_sensor_template
-    mode_photometric = camera_sensor_template.sensor_mode_photometric
-    assert mode_photometric.color_mode_color.green_spectrum_file_uri.endswith(
-        "CameraSensitivityGreen.spectrum"
-    )
-
     # blue_spectrum_file_uri
     sensor1.set_mode_photometric().set_mode_color().set_blue_spectrum_file_uri(
         uri=str(Path(test_path) / "CameraInputFiles" / "CameraSensitivityBlue.spectrum")
     )
     sensor1.commit()
     camera_sensor_template = sensor1.sensor_template_link.get().camera_sensor_template
+    assert camera_sensor_template.sensor_mode_photometric.HasField("color_mode_color")
+
     mode_photometric = camera_sensor_template.sensor_mode_photometric
+    assert mode_photometric.color_mode_color.red_spectrum_file_uri.endswith(
+        "CameraSensitivityRed.spectrum"
+    )
+    assert mode_photometric.color_mode_color.green_spectrum_file_uri.endswith(
+        "CameraSensitivityGreen.spectrum"
+    )
     assert mode_photometric.color_mode_color.blue_spectrum_file_uri.endswith(
         "CameraSensitivityBlue.spectrum"
     )
@@ -302,15 +301,6 @@ def test_create_camera_sensor(speos: Speos):
     assert mode_photometric.color_mode_color.balance_mode_userwhite.blue_gain == 4
 
     # balance_mode_display
-    sensor1.set_mode_photometric().set_mode_color().set_balance_mode_display_primaries()
-    sensor1.commit()
-    camera_sensor_template = sensor1.sensor_template_link.get().camera_sensor_template
-    mode_photometric = camera_sensor_template.sensor_mode_photometric
-    assert mode_photometric.color_mode_color.HasField("balance_mode_display")
-    assert mode_photometric.color_mode_color.balance_mode_display.red_display_file_uri == ""
-    assert mode_photometric.color_mode_color.balance_mode_display.green_display_file_uri == ""
-    assert mode_photometric.color_mode_color.balance_mode_display.blue_display_file_uri == ""
-
     sensor1.set_mode_photometric().set_mode_color().set_balance_mode_display_primaries().set_red_display_file_uri(
         uri=str(Path(test_path) / "CameraInputFiles" / "CameraSensitivityRed.spectrum")
     ).set_green_display_file_uri(
@@ -321,6 +311,7 @@ def test_create_camera_sensor(speos: Speos):
     sensor1.commit()
     camera_sensor_template = sensor1.sensor_template_link.get().camera_sensor_template
     mode_photometric = camera_sensor_template.sensor_mode_photometric
+    assert mode_photometric.color_mode_color.HasField("balance_mode_display")
     assert mode_photometric.color_mode_color.balance_mode_display.red_display_file_uri.endswith(
         "CameraSensitivityRed.spectrum"
     )


### PR DESCRIPTION
## Description
Adjust unittest so main works again with latest dev image
Bug 1229712 fixed the RPC behaviour which allowed to commit a sensor without sensor sensitivity to be set for everycolor channel. the unit test for the feature used that behavior and failed when using the latest image.

adjusted the order in unit test -> from setting, commiting and testing one by one to setting all then comiting and testing

## Issue linked
N/A

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
