### PR TITLE
ci: update dependabot cfg and code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
 .github/* @Revathyvenugopal162 @SMoraisAnsys @StefanThoene
 
 src/ansys/speos/core/*.py @StefanThoene @pluAtAnsys @echambla @jomadec
+src/ansys/speos/core/generic/**/*.py @StefanThoene @pluAtAnsys @echambla @jomadec
+src/ansys/speos/core/workflow/**/*.py @StefanThoene @pluAtAnsys @echambla @jomadec
 src/ansys/speos/core/kernel/**/*.py @etiennearnal @echambla @jomadec

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,6 @@ updates:
     labels:
       - "maintenance"
       - "dependencies"
-    reviewers:
-      - "StefanThoene"
-      - "pluatansys"
     assignees:
       - "pyansys-ci-bot"
     ignore:

--- a/doc/changelog.d/627.maintenance.md
+++ b/doc/changelog.d/627.maintenance.md
@@ -1,0 +1,1 @@
+Update dependabot cfg and code owners


### PR DESCRIPTION
## Description
Following comments https://github.com/ansys/pyspeos/pull/623#issuecomment-2974985176 and https://github.com/ansys/pyspeos/pull/623#issuecomment-2974985177, this PR removes reviewers from the dependabot's configuration and extend the code owner to cover the whole `src` folder.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
