### PR TITLE
fix: Kernel - FaceActions - check if batch is available on server - if available use batch project _fill_bodies

### DIFF
--- a/src/ansys/speos/core/project.py
+++ b/src/ansys/speos/core/project.py
@@ -691,14 +691,25 @@ class Project:
             b_feat = feat_host.create_body(name=b_data.name)
             b_feat.body_link = b_link
             b_feat._body = b_data  # instead of b_feat.reset() - this avoid a useless read in server
+
             f_links = self.client.get_items(keys=b_data.face_guids, item_type=FaceLink)
-            for f_link in f_links:
-                f_data = f_link.get()
-                f_feat = b_feat.create_face(name=f_data.name)
-                f_feat.face_link = f_link
-                f_feat._face = (
-                    f_data  # instead of f_feat.reset() - this avoid a useless read in server
-                )
+            face_db = self.client.faces()
+            if face_db._is_batch_available:
+                f_data_list = face_db.read_batch(refs=f_links)
+                for f_data, f_link in zip(f_data_list, f_links):
+                    f_feat = b_feat.create_face(name=f_data.name)
+                    f_feat.face_link = f_link
+                    f_feat._face = (
+                        f_data  # instead of f_feat.reset() - this avoid a useless read in server
+                    )
+            else:
+                for f_link in f_links:
+                    f_data = f_link.get()
+                    f_feat = b_feat.create_face(name=f_data.name)
+                    f_feat.face_link = f_link
+                    f_feat._face = (
+                        f_data  # instead of f_feat.reset() - this avoid a useless read in server
+                    )
 
     def _add_unique_ids(self):
         scene_data = self.scene_link.get()

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -478,6 +478,7 @@ def test_preview_visual_data(speos: Speos):
     p2.preview()
     # preview when there is no cad
     p3 = Project(speos=speos)
+    p3.create_root_part().commit()  # Needed for 251 server.
     sr = p3.create_source(name="Luminaire_source.2", feature_type=SourceLuminaire)
     sr.set_intensity_file_uri(uri=str(Path(test_path) / "IES_C_DETECTOR.ies"))
     sr.commit()

--- a/tests/kernel/test_geometry.py
+++ b/tests/kernel/test_geometry.py
@@ -65,7 +65,7 @@ def test_create_big_face(speos: Speos):
 
 
 def test_create_big_faces(speos: Speos):
-    """Test create big faces using batch."""
+    """Test create big faces using batch. Only available from SpeosRPC_Server 25.2."""
     assert speos.client.healthy is True
     # Get DB
     face_db = speos.client.faces()  # Create face stub from client channel
@@ -124,7 +124,7 @@ def test_create_big_faces(speos: Speos):
 
 
 def test_update_big_face(speos: Speos):
-    """Test update big face."""
+    """Test update big face. Bug on SpeosRPC_Server 25.1. Fixed from SpeosRPC_Server 25.2."""
     assert speos.client.healthy is True
     # Get DB
     face_db = speos.client.faces()  # Create face stub from client channel
@@ -175,7 +175,7 @@ def test_update_big_face(speos: Speos):
 
 
 def test_update_big_faces(speos: Speos):
-    """Test update big faces using batch."""
+    """Test update big faces using batch. Only available from SpeosRPC_Server 25.2."""
     assert speos.client.healthy is True
     # Get DB
     face_db = speos.client.faces()  # Create face stub from client channel


### PR DESCRIPTION
## Description
Kernel - FaceActions
- Check if batch is available on server
- Use non batch method when creating/reading/updating a single item.
- If batch is available, use it in project _fill_bodies
This will induce performance improvement when creating a project from speos file with a lot of faces.

## Issue linked


## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
