### PR TITLE
fix: print of protobuf messages containing special characters

### DIFF
--- a/doc/changelog.d/663.fixed.md
+++ b/doc/changelog.d/663.fixed.md
@@ -1,0 +1,1 @@
+Print of protobuf messages containing special characters

--- a/src/ansys/speos/core/kernel/proto_message_utils.py
+++ b/src/ansys/speos/core/kernel/proto_message_utils.py
@@ -57,6 +57,7 @@ def protobuf_message_to_str(message: Message, with_full_name: bool = True) -> st
             including_default_value_fields=True,
             preserving_proto_field_name=True,
             indent=4,
+            ensure_ascii=False,
         )
     else:
         ret += MessageToJson(
@@ -64,6 +65,7 @@ def protobuf_message_to_str(message: Message, with_full_name: bool = True) -> st
             always_print_fields_with_no_presence=True,
             preserving_proto_field_name=True,
             indent=4,
+            ensure_ascii=False,
         )
     return ret
 

--- a/src/ansys/speos/core/proto_message_utils.py
+++ b/src/ansys/speos/core/proto_message_utils.py
@@ -43,7 +43,7 @@ def dict_to_str(dict: dict) -> str:
     str
         String representation of the dictionary.
     """
-    return json.dumps(dict, indent=4)
+    return json.dumps(dict, indent=4, ensure_ascii=False)
 
 
 def _replace_guids(


### PR DESCRIPTION
## Description
Printing protobuf messages containing special characters was not correct.

## Issue linked

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
