### PR TITLE
fix: SubPart commit modified to work when updating an existing subpart

### DIFF
--- a/src/ansys/speos/core/part.py
+++ b/src/ansys/speos/core/part.py
@@ -295,14 +295,12 @@ class Part:
                     else:
                         update_part = False
                 else:
-                    self._parent_part._part.parts.append(
+                    parent_part_data.parts.append(
                         self._part_instance
                     )  # if no, just add it to the list of part instances
 
-                if self._parent_part.part_link is not None and update_part:
-                    self._parent_part.part_link.set(
-                        data=self._parent_part._part
-                    )  # update parent part
+                if update_part:
+                    self._parent_part.part_link.set(data=parent_part_data)  # update parent part
 
             return self
 


### PR DESCRIPTION
## Description
Create a sub part, in a project root part. 
Commit.
Modify its axis system.
Commit.
The axis system of the subpart was not modified on the server side.

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
