### PR TITLE
fix: change default version to 252

### DIFF
--- a/doc/changelog.d/687.fixed.md
+++ b/doc/changelog.d/687.fixed.md
@@ -1,0 +1,1 @@
+Change default version to 252

--- a/src/ansys/speos/core/generic/constants.py
+++ b/src/ansys/speos/core/generic/constants.py
@@ -28,7 +28,7 @@ DEFAULT_HOST: str = "localhost"
 """Default host used by Speos RPC server and client """
 DEFAULT_PORT: str = "50098"
 """Default port used by Speos RPC server and client """
-DEFAULT_VERSION: str = "251"
+DEFAULT_VERSION: str = "252"
 """Latest supported Speos version of the current PySpeos Package"""
 MAX_SERVER_MESSAGE_LENGTH: int = int(os.environ.get("SPEOS_MAX_MESSAGE_LENGTH", 256 * 1024**2))
 """Maximum message length value accepted by the Speos RPC server,


### PR DESCRIPTION
## Description
default version was still set to 251

## Issue linked
#686

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
