### PR TITLE
build: install comtypes only for windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies=[
     "ansys-api-speos==0.15.2",
     "ansys-tools-path>=0.3.1",
     "numpy>=1.20.3,<3",
-    "comtypes>=1.4,<1.5",
+    "comtypes>=1.4,<1.5; platform_system=='Windows'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Description
Since `comtypes.client.CreateObject` is only used for windows, it would be great to only install it on that platform. Strange behavior have been detected on another workflow when using `pyspeos` on other system, e.g. Github's runner `ubuntu-22.04`.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
