### PR TITLE
Handle specificities of new server 25R2 SP1 and backward compatibility with previous servers.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies=[
     "protobuf>=3.20,<7",
     "grpcio>=1.50.0,<1.75",
     "grpcio-health-checking>=1.45.0,<1.68",
-    "ansys-api-speos==0.15.2",
+    "ansys-api-speos==0.15.3",
     "ansys-tools-path>=0.3.1",
     "numpy>=1.20.3,<3",
     "comtypes>=1.4,<1.5; platform_system=='Windows'",

--- a/src/ansys/speos/core/kernel/face.py
+++ b/src/ansys/speos/core/kernel/face.py
@@ -304,7 +304,7 @@ class FaceStub(CrudStub):
                             sizes=[
                                 len(message.vertices),
                                 len(message.facets),
-                                len(message.texture_coordinates_channels),
+                                len(message.vertices_data),
                             ],
                         )
                     )

--- a/src/ansys/speos/core/kernel/scene.py
+++ b/src/ansys/speos/core/kernel/scene.py
@@ -31,6 +31,7 @@ from ansys.api.speos.scene.v2 import (
 )
 from ansys.speos.core.kernel.crud import CrudItem, CrudStub
 from ansys.speos.core.kernel.proto_message_utils import protobuf_message_to_str
+from ansys.speos.core.kernel.sop_template import ProtoSOPTemplate, SOPTemplateStub
 
 ProtoScene = messages.Scene
 """Scene protobuf class : ansys.api.speos.scene.v2.scene_pb2.Scene"""
@@ -171,6 +172,39 @@ class SceneStub(CrudStub):
     def __init__(self, channel):
         super().__init__(stub=service.ScenesManagerStub(channel=channel))
         self._actions_stub = service.SceneActionsStub(channel=channel)
+        self._is_texture_available = self._check_if_texture_available(channel=channel)
+
+    def _check_if_texture_available(self, channel) -> bool:
+        sop_t_stub = SOPTemplateStub(channel=channel)
+        # Create SOPTemplate then scene
+        sop_t_link = sop_t_stub.create(
+            message=ProtoSOPTemplate(
+                name="checkForTextureAvailability",
+                optical_polished=ProtoSOPTemplate.OpticalPolished(),
+            )
+        )
+        sce_link = self.create(
+            ProtoScene(
+                name="checkForTextureAvailability",
+                materials=[
+                    ProtoScene.MaterialInstance(
+                        name="checkForTextureAvailability", sop_guids=[sop_t_link.key]
+                    )
+                ],
+            )
+        )
+
+        # Read scene (aim is to check if the server uses new field for sop_guid or old sop_guids)
+        sce_msg = sce_link.get()
+
+        # Don't forget to delete created objects
+        sop_t_link.delete()
+        sce_link.delete()
+
+        # Check presence of sop_guid field -> if yes then texture is available
+        if sce_msg.materials[0].HasField("sop_guid"):
+            return True
+        return False
 
     def create(self, message: ProtoScene = None) -> SceneLink:
         """Create a new entry.

--- a/src/ansys/speos/core/opt_prop.py
+++ b/src/ansys/speos/core/opt_prop.py
@@ -436,8 +436,12 @@ class OptProp:
                 self.sop_template_link = self._project.client.sop_templates().create(
                     message=self._sop_template
                 )
-                self._material_instance.ClearField("sop_guids")
-                self._material_instance.sop_guids.append(self.sop_template_link.key)
+                if self._project.client.scenes()._is_texture_available:
+                    self._material_instance.ClearField("sop_guid")
+                    self._material_instance.sop_guid = self.sop_template_link.key
+                else:
+                    self._material_instance.ClearField("sop_guids")
+                    self._material_instance.sop_guids.append(self.sop_template_link.key)
         elif self.sop_template_link.get() != self._sop_template:
             self.sop_template_link.set(
                 data=self._sop_template
@@ -519,7 +523,8 @@ class OptProp:
             self.sop_template_link.delete()
             self.sop_template_link = None
 
-        # Reset then the sop_guids (as the sop template was deleted just above)
+        # Reset then the sop_guid/sop_guids fields (as the sop template was deleted just above)
+        self._material_instance.ClearField("sop_guid")
         self._material_instance.ClearField("sop_guids")
 
         # Remove the material instance from the scene
@@ -537,11 +542,13 @@ class OptProp:
         self._material_instance.metadata.pop("UniqueId")
         return self
 
-    def _fill(self, mat_inst):
+    def _fill(self, mat_inst: ProtoScene.MaterialInstance):
         self._unique_id = mat_inst.metadata["UniqueId"]
         self._material_instance = mat_inst
         self.vop_template_link = self._project.client[mat_inst.vop_guid]
-        if len(mat_inst.sop_guids) > 0:
+        if mat_inst.HasField("sop_guid"):
+            self.sop_template_link = self._project.client[mat_inst.sop_guid]
+        elif len(mat_inst.sop_guids) > 0:
             self.sop_template_link = self._project.client[mat_inst.sop_guids[0]]
         else:  # Specific case for ambient material
             self._sop_template = None

--- a/src/ansys/speos/core/workflow/combine_speos.py
+++ b/src/ansys/speos/core/workflow/combine_speos.py
@@ -151,7 +151,7 @@ def _combine(
         part_data.parts.append(part_inst)
 
         for mat in scene_tmp_data.materials:
-            if len(mat.sop_guids) > 0:
+            if mat.HasField("sop_guid") or mat.HasField("texture") or len(mat.sop_guids) > 0:
                 mat.name = spc.name + "." + mat.name
                 mat.geometries.geo_paths[:] = [spc.name + "/" + x for x in mat.geometries.geo_paths]
                 scene_data.materials.append(mat)

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -341,8 +341,13 @@ def test_from_file(speos: Speos):
 
     # And that the feature retrieved has a real impact on the project
     feat_ops[0].set_surface_mirror(reflectance=60).commit()
-    assert speos.client[p.scene_link.get().materials[2].sop_guids[0]].get().HasField("mirror")
-    assert speos.client[p.scene_link.get().materials[2].sop_guids[0]].get().mirror.reflectance == 60
+    mat2 = p.scene_link.get().materials[2]
+    if mat2.HasField("sop_guid"):
+        assert speos.client[mat2.sop_guid].get().HasField("mirror")
+        assert speos.client[mat2.sop_guid].get().mirror.reflectance == 60
+    else:
+        assert speos.client[mat2.sop_guids[0]].get().HasField("mirror")
+        assert speos.client[mat2.sop_guids[0]].get().mirror.reflectance == 60
 
     # Check that ambient mat has no sop
     feat_op_ambients = p.find(name=p.scene_link.get().materials[-1].name)

--- a/tests/kernel/test_scene.py
+++ b/tests/kernel/test_scene.py
@@ -242,6 +242,33 @@ def create_basic_scene(speos: Speos) -> SceneLink:
         )
     )
 
+    material_inst_1 = None
+    material_inst_fop = None
+    if scene_db._is_texture_available:
+        material_inst_1 = ProtoScene.MaterialInstance(
+            name="Material.1",
+            vop_guid=opaque_t.key,
+            sop_guid=mirror_100_t.key,
+            geometries=ProtoScene.GeoPaths(geo_paths=["Body0:1"]),
+        )
+        material_inst_fop = ProtoScene.MaterialInstance(
+            name="FOP.1",
+            sop_guid=mirror_100_t.key,
+            geometries=ProtoScene.GeoPaths(geo_paths=["BodySource:1/FaceSource:1"]),
+        )
+    else:
+        material_inst_1 = ProtoScene.MaterialInstance(
+            name="Material.1",
+            vop_guid=opaque_t.key,
+            sop_guids=[mirror_100_t.key],
+            geometries=ProtoScene.GeoPaths(geo_paths=["Body0:1"]),
+        )
+        material_inst_fop = ProtoScene.MaterialInstance(
+            name="FOP.1",
+            sop_guids=[mirror_100_t.key],
+            geometries=ProtoScene.GeoPaths(geo_paths=["BodySource:1/FaceSource:1"]),
+        )
+
     # Create scene
     scene = scene_db.create(
         message=ProtoScene(
@@ -249,17 +276,8 @@ def create_basic_scene(speos: Speos) -> SceneLink:
             description="scene from scratch",
             part_guid=main_part.key,
             materials=[
-                ProtoScene.MaterialInstance(
-                    name="Material.1",
-                    vop_guid=opaque_t.key,
-                    sop_guids=[mirror_100_t.key],
-                    geometries=ProtoScene.GeoPaths(geo_paths=["Body0:1"]),
-                ),
-                ProtoScene.MaterialInstance(
-                    name="FOP.1",
-                    sop_guids=[mirror_100_t.key],
-                    geometries=ProtoScene.GeoPaths(geo_paths=["BodySource:1/FaceSource:1"]),
-                ),
+                material_inst_1,
+                material_inst_fop,
             ],
             sources=[
                 ProtoScene.SourceInstance(


### PR DESCRIPTION
## Description
Handle specificities of new server 25R2 SP1 and backward compatibility with previous servers.
New field sop_guid in MaterialInstance (instead of sop_guids)

## Issue linked

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
