### PR TITLE
refactor: subprocess related line of codes

### DIFF
--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -50,6 +50,41 @@ Development installation
 In case you want to support the development of PySpeos, install the repository
 in development mode. For more information, refer to the `README`_.
 
+.. _ref_security_consideration:
+
+Security considerations
+=======================
+
+This section provides information on security considerations for the use
+of PySpeos. It is important to understand the capabilities which PySpeos
+provides, especially when using it to build applications or scripts that
+accept untrusted input.
+
+If a function displays a warning that redirects to this page, it indicates
+that the function may expose security risks when used improperly.
+In such cases, it is essential to pay close attention to:
+
+- **Function arguments**: Ensure that arguments passed to the function are
+  properly validated and do not contain untrusted content such as arbitrary
+  file paths, shell commands, or serialized data.
+- **Environment variables**: Be cautious of environment variables that can
+  influence the behavior of the function, particularly if they are user-defined
+  or inherited from an untrusted execution context.
+
+Always validate external input, avoid executing arbitrary commands or code,
+and follow the principle of least privilege when developing with PySpeos.
+
+Launching local Speos RPC server
+--------------------------------
+
+The :py:func:`.local_speos_rpc_server` function can be used to launch Speos RPC
+server locally. The executable which is launched is configured with the function
+parameters and environment variables. This may allow an attacker to launch 
+arbitrary executables on the system. When exposing the launch function to 
+untrusted users, it is important to validate that the executable path, 
+environment variables (for example ``AWP_ROOT``) are safe.
+Otherwise, hard-code them in the application.
+
 Frequently asked questions
 ==========================
 

--- a/src/ansys/speos/core/kernel/client.py
+++ b/src/ansys/speos/core/kernel/client.py
@@ -175,6 +175,12 @@ class SpeosClient:
             self._channel = channel
             self._target = str(channel)
         else:
+            if host == "0.0.0.0":  # nosec
+                warnings.warn(
+                    "The service is exposed on all network interfaces. This is a security risk.",
+                    stacklevel=2
+                )
+
             self._host = host
             self._port = port
             self._target = f"{host}:{port}"


### PR DESCRIPTION
## Description
Add additional checks and documentation for methods with lines of code where subprocess is used. When users try to instantiate the `SpeosClient` class without providing channel and using `0.0.0.0` as host, a warning is emitted because the service is exposed on all network interfaces.

## Issue linked
Associated to #645 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
