### PR TITLE
ci: add backwards compatibility test

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        speos-version:   ["242", "2025.1.0", "252"]
+        speos-version:   ["242", "251", "252"]
         # grpc-version:   ["1.75.0", "1.74.0", "1.73.0"]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -64,7 +64,7 @@ jobs:
         env:
           ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
         run: |
-          if [[ "${{ matrix.speos-version }}" == "2025.1.0" ]]; then
+          if [[ "${{ matrix.speos-version }}" == "251" ]]; then
             echo "Running without --host flag"
             docker run --detach --name speos-rpc -p 127.0.0.1:50098:50098 -e SPEOS_LOG_LEVEL=2 -e ANSYSLMD_LICENSE_FILE=${{ env.ANSYSLMD_LICENSE_FILE }} -v "${{ github.workspace }}/tests/assets:/app/assets" --entrypoint /app/SpeosRPC_Server.x ghcr.io/ansys/speos-rpc:${{ matrix.speos-version }} -m 25000000
           else
@@ -75,7 +75,7 @@ jobs:
       - name: Run pytest
         run: |
           . .venv/bin/activate
-          if [[ "${{ matrix.speos-version }}" == "2025.1.0" ]]; then
+          if [[ "${{ matrix.speos-version }}" == "251" ]]; then
             	xvfb-run pytest -s -k SPEOS_25_1_0
           else
             	xvfb-run pytest -s

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -74,18 +74,20 @@ jobs:
       - name: Run pytest Backwards Compatibility
         run: |
           . .venv/bin/activate
+          major_version=${{ matrix.speos-major-version }}
+          minor_version=${{ matrix.speos-minor-version }}
 
           for major in 25; do
-            if [ ${{ matrix.speos-major-version }} -ge "$major" ]; then
-              for minor in 1, 2; do
-                if [ ${{ matrix.speos-minor-version }} -ge "$minor" ]; then
-                  xvfb-run pytest -s -k SPEOS_$major_$minor_0
+            if [ "$major_version" -ge "$major" ]; then
+              for minor in 1 2; do
+                if [ "$minor_version" -ge "$minor" ]; then
+                  xvfb-run pytest -s -k SPEOS_${major}_${minor}_0_MIN
                 else
-                  echo "pytest for Speos $major_$minor skipped"
+                  echo "pytest for Speos ${major}_${minor} skipped"
                 fi
               done
             else
-              echo "pytest for Speos ${{ matrix.speos-major-version }}${{ matrix.speos-minor-version }}"
+              echo "pytest for Speos ${major_version}_${minor_version} undefined"
             fi
           done
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        grpc-version:   ["1.75.0", "1.74.0", "1.73.0"]
+        # grpc-version:   ["1.75.0", "1.74.0", "1.73.0"]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -46,11 +46,11 @@ jobs:
           pip install --upgrade build wheel
           pip install .[tests]
 
-      - name: Install gRPC ${{ matrix.grpc-version }} version
-        run: |
-          . .venv/bin/activate
-          pip uninstall -y grpcio
-          pip install grpcio==${{ matrix.grpc-version }}
+      # - name: Install gRPC ${{ matrix.grpc-version }} version
+      #   run: |
+      #     . .venv/bin/activate
+      #     pip uninstall -y grpcio
+      #     pip install grpcio==${{ matrix.grpc-version }}
 
       - name: Login to GitHub Packages
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        speos-version: ["251", "252"]
+        speos-version: ["251", "252", "dev"]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -68,15 +68,21 @@ jobs:
       - name: Run pytest UAT
         run: |
           . .venv/bin/activate
-          xvfb-run pytest -s -k SPEOS_UAT
+          xvfb-run pytest -s -m SPEOS_UAT
 
       - name: Run pytest Backwards Compatibility for Speos ${{ matrix.speos-version }}
         run: |
           . .venv/bin/activate
           speos_version=${{ matrix.speos-version }}
+          maximal_absolute=999
 
-          echo "run pytest for Speos ${speos_version}"
-          xvfb-run pytest -s --supported-features=$speos_version
+          if [[ "$speos_version" == "dev" ]]; then
+            echo "run pytest for all available features"
+            xvfb-run pytest -s --supported-features=$maximal_absolute
+          else
+            echo "run pytest for Speos ${speos_version} supported features"
+            xvfb-run pytest -s --supported-features=$speos_version
+          fi
 
       - name: Upload Coverage Results
         if: always()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        speos-version:   ["242", "251", "252"]
+        speos-version:   ["242", "2025.1.0", "252"]
         # grpc-version:   ["1.75.0", "1.74.0", "1.73.0"]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -64,7 +64,7 @@ jobs:
         env:
           ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
         run: |
-          if [[ "${{ matrix.speos-version }}" == "251" ]]; then
+          if [[ "${{ matrix.speos-version }}" == "2025.1.0" ]]; then
             echo "Running without --host flag"
             docker run --detach --name speos-rpc -p 127.0.0.1:50098:50098 -e SPEOS_LOG_LEVEL=2 -e ANSYSLMD_LICENSE_FILE=${{ env.ANSYSLMD_LICENSE_FILE }} -v "${{ github.workspace }}/tests/assets:/app/assets" --entrypoint /app/SpeosRPC_Server.x ghcr.io/ansys/speos-rpc:${{ matrix.speos-version }} -m 25000000
           else
@@ -75,7 +75,7 @@ jobs:
       - name: Run pytest
         run: |
           . .venv/bin/activate
-          if [[ "${{ matrix.speos-version }}" == "251" ]]; then
+          if [[ "${{ matrix.speos-version }}" == "2025.1.0" ]]; then
             	xvfb-run pytest -s -k SPEOS_25_1_0
           else
             	xvfb-run pytest -s

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,12 +58,14 @@ jobs:
         env:
           ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
         run: |
-          if [[ "${{ matrix.speos-major-version }}${{ matrix.speos-minor-version }}" == "251" ]]; then
+          speos_version=${{ matrix.speos-major-version }}${{ matrix.speos-minor-version }}
+
+          if [[ "$speos_version" == "251" ]]; then
             echo "Running without --host flag"
-            docker run --detach --name speos-rpc -p 127.0.0.1:50098:50098 -e SPEOS_LOG_LEVEL=2 -e ANSYSLMD_LICENSE_FILE=${{ env.ANSYSLMD_LICENSE_FILE }} -v "${{ github.workspace }}/tests/assets:/app/assets" --entrypoint /app/SpeosRPC_Server.x ghcr.io/ansys/speos-rpc:${{ matrix.speos-major-version }}${{ matrix.speos-minor-version }} -m 25000000
+            docker run --detach --name speos-rpc -p 127.0.0.1:50098:50098 -e SPEOS_LOG_LEVEL=2 -e ANSYSLMD_LICENSE_FILE=${{ env.ANSYSLMD_LICENSE_FILE }} -v "${{ github.workspace }}/tests/assets:/app/assets" --entrypoint /app/SpeosRPC_Server.x ghcr.io/ansys/speos-rpc:$speos_version -m 25000000
           else
             echo "Running with --host 0.0.0.0"
-            docker run --detach --name speos-rpc -p 127.0.0.1:50098:50098 -e SPEOS_LOG_LEVEL=2 -e ANSYSLMD_LICENSE_FILE=${{ env.ANSYSLMD_LICENSE_FILE }} -v "${{ github.workspace }}/tests/assets:/app/assets" --entrypoint /app/SpeosRPC_Server.x ghcr.io/ansys/speos-rpc:${{ matrix.speos-major-version }}${{ matrix.speos-minor-version }} -m 25000000 --host 0.0.0.0
+            docker run --detach --name speos-rpc -p 127.0.0.1:50098:50098 -e SPEOS_LOG_LEVEL=2 -e ANSYSLMD_LICENSE_FILE=${{ env.ANSYSLMD_LICENSE_FILE }} -v "${{ github.workspace }}/tests/assets:/app/assets" --entrypoint /app/SpeosRPC_Server.x ghcr.io/ansys/speos-rpc:$speos_version -m 25000000 --host 0.0.0.0
           fi
 
       - name: Run pytest UAT
@@ -72,15 +74,23 @@ jobs:
           echo "Running pytest UAT"
           xvfb-run pytest -s -k SPEOS_UAT
 
-      - name: Run pytest
+      - name: Run pytest Backwards Compatibility
         run: |
           . .venv/bin/activate
-          if [[ "${{ matrix.speos-major-version }}${{ matrix.speos-minor-version }}" == "251" ]]; then
-              echo "Running pytest Speos ${{ matrix.speos-major-version }}${{ matrix.speos-minor-version }} version"
-            	xvfb-run pytest -s -k SPEOS_25_1_0_MIN
-          else
-            	xvfb-run pytest -s
-          fi
+
+          for major in 25; do
+            if [ ${{ matrix.speos-major-version }} -ge "$major" ]; then
+              for minor in 1, 2; do
+                if [ ${{ matrix.speos-minor-version }} -ge "$minor" ]; then
+                  xvfb-run pytest -s -k SPEOS_$major_$minor_0
+                else
+                  echo "pytest for Speos $major_$minor skipped"
+                fi
+              done
+            else
+              echo "pytest for Speos ${{ matrix.speos-major-version }}${{ matrix.speos-minor-version }}"
+            fi
+          done
 
       - name: Upload Coverage Results
         if: always()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -64,7 +64,13 @@ jobs:
         env:
           ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
         run: |
-          docker run --detach --name speos-rpc -p 127.0.0.1:50098:50098 -e SPEOS_LOG_LEVEL=2 -e ANSYSLMD_LICENSE_FILE=${{ env.ANSYSLMD_LICENSE_FILE }} -v "${{ github.workspace }}/tests/assets:/app/assets" --entrypoint /app/SpeosRPC_Server.x ghcr.io/ansys/speos-rpc:${{ matrix.speos-version }} -m 25000000 --host 0.0.0.0
+          if [[ "${{ matrix.speos-version }}" == "251" ]]; then
+            echo "Running without --host flag"
+            docker run --detach --name speos-rpc -p 127.0.0.1:50098:50098 -e SPEOS_LOG_LEVEL=2 -e ANSYSLMD_LICENSE_FILE=${{ env.ANSYSLMD_LICENSE_FILE }} -v "${{ github.workspace }}/tests/assets:/app/assets" --entrypoint /app/SpeosRPC_Server.x ghcr.io/ansys/speos-rpc:${{ matrix.speos-version }} -m 25000000
+          else
+            echo "Running with --host 0.0.0.0"
+            docker run --detach --name speos-rpc -p 127.0.0.1:50098:50098 -e SPEOS_LOG_LEVEL=2 -e ANSYSLMD_LICENSE_FILE=${{ env.ANSYSLMD_LICENSE_FILE }} -v "${{ github.workspace }}/tests/assets:/app/assets" --entrypoint /app/SpeosRPC_Server.x ghcr.io/ansys/speos-rpc:${{ matrix.speos-version }} -m 25000000 --host 0.0.0.0
+          fi
 
       - name: Run pytest
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Run pytest
         run: |
           . .venv/bin/activate
-          xvfb-run pytest -xs
+          xvfb-run pytest -s
 
       - name: Upload Coverage Results
         if: always()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -71,7 +71,7 @@ jobs:
           . .venv/bin/activate
           xvfb-run pytest -s -k SPEOS_UAT
 
-      - name: Run pytest Backwards Compatibility
+      - name: Run pytest Backwards Compatibility for ${{ matrix.speos-major-version }}R${{ matrix.speos-minor-version }}
         run: |
           . .venv/bin/activate
           major_version=${{ matrix.speos-major-version }}
@@ -79,15 +79,16 @@ jobs:
 
           for major in 25; do
             if [ "$major_version" -ge "$major" ]; then
-              for minor in 1 2; do
+              for minor in $(seq 2 -1 1); do
                 if [ "$minor_version" -ge "$minor" ]; then
+                  echo "run pytest for Speos ${major}R${minor}"
                   xvfb-run pytest -s -k SPEOS_${major}_${minor}_0_MIN
                 else
-                  echo "pytest for Speos ${major}_${minor} skipped"
+                  echo "skip pytest for Speos ${major}R${minor}"
                 fi
               done
             else
-              echo "pytest for Speos ${major_version}_${minor_version} undefined"
+              echo "undefined pytest for Speos ${major_version}R${minor_version}"
             fi
           done
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        speos-version:   ["242", "251", "252"]
+        speos-major-version: ["24", "25"]
+        speos-minor-version: ["1", "2"]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -57,7 +58,7 @@ jobs:
         env:
           ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
         run: |
-          if [[ "${{ matrix.speos-version }}" == "251" ]]; then
+          if [[ "${{ matrix.speos-major-version }}${{ matrix.speos-minor-version }}" == "251" ]]; then
             echo "Running without --host flag"
             docker run --detach --name speos-rpc -p 127.0.0.1:50098:50098 -e SPEOS_LOG_LEVEL=2 -e ANSYSLMD_LICENSE_FILE=${{ env.ANSYSLMD_LICENSE_FILE }} -v "${{ github.workspace }}/tests/assets:/app/assets" --entrypoint /app/SpeosRPC_Server.x ghcr.io/ansys/speos-rpc:${{ matrix.speos-version }} -m 25000000
           else
@@ -68,8 +69,8 @@ jobs:
       - name: Run pytest
         run: |
           . .venv/bin/activate
-          if [[ "${{ matrix.speos-version }}" == "251" ]]; then
-            	xvfb-run pytest -s -k SPEOS_25_1_0
+          if [[ "${{ matrix.speos-major-version }}${{ matrix.speos-minor-version }}" == "251" ]]; then
+              echo "Running pytest Speos ${{ matrix.speos-major-version }}${{ matrix.speos-minor-version }} version"
           else
             	xvfb-run pytest -s
           fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,7 +75,11 @@ jobs:
       - name: Run pytest
         run: |
           . .venv/bin/activate
-          xvfb-run pytest -s
+          if [[ "${{ matrix.speos-version }}" == "251" ]]; then
+            	xvfb-run pytest -s -k "version==25.1.0"
+          else
+            	xvfb-run pytest -s
+          fi
 
       - name: Upload Coverage Results
         if: always()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,17 +61,14 @@ jobs:
           speos_version=${{ matrix.speos-major-version }}${{ matrix.speos-minor-version }}
 
           if [[ "$speos_version" == "251" ]]; then
-            echo "Running without --host flag"
             docker run --detach --name speos-rpc -p 127.0.0.1:50098:50098 -e SPEOS_LOG_LEVEL=2 -e ANSYSLMD_LICENSE_FILE=${{ env.ANSYSLMD_LICENSE_FILE }} -v "${{ github.workspace }}/tests/assets:/app/assets" --entrypoint /app/SpeosRPC_Server.x ghcr.io/ansys/speos-rpc:$speos_version -m 25000000
           else
-            echo "Running with --host 0.0.0.0"
             docker run --detach --name speos-rpc -p 127.0.0.1:50098:50098 -e SPEOS_LOG_LEVEL=2 -e ANSYSLMD_LICENSE_FILE=${{ env.ANSYSLMD_LICENSE_FILE }} -v "${{ github.workspace }}/tests/assets:/app/assets" --entrypoint /app/SpeosRPC_Server.x ghcr.io/ansys/speos-rpc:$speos_version -m 25000000 --host 0.0.0.0
           fi
 
       - name: Run pytest UAT
         run: |
           . .venv/bin/activate
-          echo "Running pytest UAT"
           xvfb-run pytest -s -k SPEOS_UAT
 
       - name: Run pytest Backwards Compatibility

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,8 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        speos-major-version: ["25"]
-        speos-minor-version: ["1", "2"]
+        speos-version: ["251", "252"]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -58,7 +57,7 @@ jobs:
         env:
           ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
         run: |
-          speos_version=${{ matrix.speos-major-version }}${{ matrix.speos-minor-version }}
+          speos_version=${{ matrix.speos-version }}
 
           if [[ "$speos_version" == "251" ]]; then
             docker run --detach --name speos-rpc -p 127.0.0.1:50098:50098 -e SPEOS_LOG_LEVEL=2 -e ANSYSLMD_LICENSE_FILE=${{ env.ANSYSLMD_LICENSE_FILE }} -v "${{ github.workspace }}/tests/assets:/app/assets" --entrypoint /app/SpeosRPC_Server.x ghcr.io/ansys/speos-rpc:$speos_version -m 25000000
@@ -71,33 +70,20 @@ jobs:
           . .venv/bin/activate
           xvfb-run pytest -s -k SPEOS_UAT
 
-      - name: Run pytest Backwards Compatibility for ${{ matrix.speos-major-version }}R${{ matrix.speos-minor-version }}
+      - name: Run pytest Backwards Compatibility for Speos ${{ matrix.speos-version }}
         run: |
           . .venv/bin/activate
-          major_version=${{ matrix.speos-major-version }}
-          minor_version=${{ matrix.speos-minor-version }}
+          speos_version=${{ matrix.speos-version }}
 
-          for major in 25; do
-            if [ "$major_version" -ge "$major" ]; then
-              for minor in $(seq 2 -1 1); do
-                if [ "$minor_version" -ge "$minor" ]; then
-                  echo "run pytest for Speos ${major}R${minor}"
-                  xvfb-run pytest -s -k SPEOS_${major}_${minor}_0_MIN
-                else
-                  echo "skip pytest for Speos ${major}R${minor}"
-                fi
-              done
-            else
-              echo "undefined pytest for Speos ${major_version}R${minor_version}"
-            fi
-          done
+          echo "run pytest for Speos ${speos_version}"
+          xvfb-run pytest -s --supported-features=$speos_version
 
       - name: Upload Coverage Results
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           path: .cov/html
-          name: coverage-html-ubuntu-${{ matrix.python-version }}-${{ matrix.speos-major-version }}-${{ matrix.speos-minor-version }}
+          name: coverage-html-ubuntu-${{ matrix.python-version }}-${{ matrix.speos-version }}
           retention-days: 7
 
       - name: Upload coverage to Codecov
@@ -106,7 +92,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: .cov/xml
-          name: coverage-html-ubuntu-${{ matrix.python-version }}-${{ matrix.speos-major-version }}-${{ matrix.speos-minor-version }}
+          name: coverage-html-ubuntu-${{ matrix.python-version }}-${{ matrix.speos-version }}
 
       - name: Stop container
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        speos-major-version: ["24", "25"]
+        speos-major-version: ["25"]
         speos-minor-version: ["1", "2"]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,6 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        grpc-version:   ["1.75.0", "1.74.0", "1.73.0"]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -45,6 +46,12 @@ jobs:
           pip install --upgrade build wheel
           pip install .[tests]
 
+      - name: Install gRPC ${{ matrix.grpc-version }} version
+        run: |
+          . .venv/bin/activate
+          pip uninstall -y grpcio
+          pip install grpcio==${{ matrix.grpc-version }}
+
       - name: Login to GitHub Packages
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
@@ -68,7 +75,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           path: .cov/html
-          name: coverage-html-ubuntu-${{ matrix.python-version }}
+          name: coverage-html-ubuntu-${{ matrix.python-version }}-${{ matrix.grpc-version }}
           retention-days: 7
 
       - name: Upload coverage to Codecov
@@ -77,7 +84,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: .cov/xml
-          name: coverage-html-ubuntu-${{ matrix.python-version }}
+          name: coverage-html-ubuntu-${{ matrix.python-version }}-${{ matrix.grpc-version }}
 
       - name: Stop container
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -96,7 +96,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           path: .cov/html
-          name: coverage-html-ubuntu-${{ matrix.python-version }}-${{ matrix.grpc-version }}
+          name: coverage-html-ubuntu-${{ matrix.python-version }}-${{ matrix.speos-major-version }}-${{ matrix.speos-minor-version }}
           retention-days: 7
 
       - name: Upload coverage to Codecov
@@ -105,7 +105,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: .cov/xml
-          name: coverage-html-ubuntu-${{ matrix.python-version }}-${{ matrix.grpc-version }}
+          name: coverage-html-ubuntu-${{ matrix.python-version }}-${{ matrix.speos-major-version }}-${{ matrix.speos-minor-version }}
 
       - name: Stop container
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -66,6 +66,12 @@ jobs:
             docker run --detach --name speos-rpc -p 127.0.0.1:50098:50098 -e SPEOS_LOG_LEVEL=2 -e ANSYSLMD_LICENSE_FILE=${{ env.ANSYSLMD_LICENSE_FILE }} -v "${{ github.workspace }}/tests/assets:/app/assets" --entrypoint /app/SpeosRPC_Server.x ghcr.io/ansys/speos-rpc:${{ matrix.speos-version }} -m 25000000 --host 0.0.0.0
           fi
 
+      - name: Run pytest UAT
+        run: |
+          . .venv/bin/activate
+          echo "Running pytest UAT"
+          xvfb-run pytest -s -k SPEOS_UAT
+
       - name: Run pytest
         run: |
           . .venv/bin/activate

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,7 +53,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Start container
+      - name: Start container for Speos ${{ matrix.speos-version }}
         env:
           ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           . .venv/bin/activate
           if [[ "${{ matrix.speos-version }}" == "251" ]]; then
-            	xvfb-run pytest -s -k "version==25.1.0"
+            	xvfb-run pytest -s -k SPEOS_25_1_0
           else
             	xvfb-run pytest -s
           fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -71,6 +71,7 @@ jobs:
           . .venv/bin/activate
           if [[ "${{ matrix.speos-major-version }}${{ matrix.speos-minor-version }}" == "251" ]]; then
               echo "Running pytest Speos ${{ matrix.speos-major-version }}${{ matrix.speos-minor-version }} version"
+            	xvfb-run pytest -s -k SPEOS_25_1_0_MIN
           else
             	xvfb-run pytest -s
           fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,10 +60,10 @@ jobs:
         run: |
           if [[ "${{ matrix.speos-major-version }}${{ matrix.speos-minor-version }}" == "251" ]]; then
             echo "Running without --host flag"
-            docker run --detach --name speos-rpc -p 127.0.0.1:50098:50098 -e SPEOS_LOG_LEVEL=2 -e ANSYSLMD_LICENSE_FILE=${{ env.ANSYSLMD_LICENSE_FILE }} -v "${{ github.workspace }}/tests/assets:/app/assets" --entrypoint /app/SpeosRPC_Server.x ghcr.io/ansys/speos-rpc:${{ matrix.speos-version }} -m 25000000
+            docker run --detach --name speos-rpc -p 127.0.0.1:50098:50098 -e SPEOS_LOG_LEVEL=2 -e ANSYSLMD_LICENSE_FILE=${{ env.ANSYSLMD_LICENSE_FILE }} -v "${{ github.workspace }}/tests/assets:/app/assets" --entrypoint /app/SpeosRPC_Server.x ghcr.io/ansys/speos-rpc:${{ matrix.speos-major-version }}${{ matrix.speos-minor-version }} -m 25000000
           else
             echo "Running with --host 0.0.0.0"
-            docker run --detach --name speos-rpc -p 127.0.0.1:50098:50098 -e SPEOS_LOG_LEVEL=2 -e ANSYSLMD_LICENSE_FILE=${{ env.ANSYSLMD_LICENSE_FILE }} -v "${{ github.workspace }}/tests/assets:/app/assets" --entrypoint /app/SpeosRPC_Server.x ghcr.io/ansys/speos-rpc:${{ matrix.speos-version }} -m 25000000 --host 0.0.0.0
+            docker run --detach --name speos-rpc -p 127.0.0.1:50098:50098 -e SPEOS_LOG_LEVEL=2 -e ANSYSLMD_LICENSE_FILE=${{ env.ANSYSLMD_LICENSE_FILE }} -v "${{ github.workspace }}/tests/assets:/app/assets" --entrypoint /app/SpeosRPC_Server.x ghcr.io/ansys/speos-rpc:${{ matrix.speos-major-version }}${{ matrix.speos-minor-version }} -m 25000000 --host 0.0.0.0
           fi
 
       - name: Run pytest UAT

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,6 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        speos-version:   ["231", "232", "241", "242", "251", "252"]
         # grpc-version:   ["1.75.0", "1.74.0", "1.73.0"]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -63,7 +64,7 @@ jobs:
         env:
           ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
         run: |
-          docker run --detach --name speos-rpc -p 127.0.0.1:50098:50098 -e SPEOS_LOG_LEVEL=2 -e ANSYSLMD_LICENSE_FILE=${{ env.ANSYSLMD_LICENSE_FILE }} -v "${{ github.workspace }}/tests/assets:/app/assets" --entrypoint /app/SpeosRPC_Server.x ghcr.io/ansys/speos-rpc:dev -m 25000000 --host 0.0.0.0
+          docker run --detach --name speos-rpc -p 127.0.0.1:50098:50098 -e SPEOS_LOG_LEVEL=2 -e ANSYSLMD_LICENSE_FILE=${{ env.ANSYSLMD_LICENSE_FILE }} -v "${{ github.workspace }}/tests/assets:/app/assets" --entrypoint /app/SpeosRPC_Server.x ghcr.io/ansys/speos-rpc:${{ matrix.speos-version }} -m 25000000 --host 0.0.0.0
 
       - name: Run pytest
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         speos-version:   ["242", "251", "252"]
-        # grpc-version:   ["1.75.0", "1.74.0", "1.73.0"]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -46,12 +45,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade build wheel
           pip install .[tests]
-
-      # - name: Install gRPC ${{ matrix.grpc-version }} version
-      #   run: |
-      #     . .venv/bin/activate
-      #     pip uninstall -y grpcio
-      #     pip install grpcio==${{ matrix.grpc-version }}
 
       - name: Login to GitHub Packages
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        speos-version:   ["231", "232", "241", "242", "251", "252"]
+        speos-version:   ["242", "251", "252"]
         # grpc-version:   ["1.75.0", "1.74.0", "1.73.0"]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,8 +148,10 @@ minversion = "7.1"
 addopts = "-vvv --color=yes -ra --durations=25 --cov=ansys.speos --cov-report html:.cov/html --cov-report xml:.cov/xml --cov-report term"
 testpaths = ["tests"]
 markers = [
-    "SPEOS_25_2_0: Minimal required version Speos RPC 25R2 Service Pack 0.",
-    "SPEOS_25_1_0: Minimal required version Speos RPC 25R1 Service Pack 0."
+    "SPEOS_UAT: Supported on all Speos versions, User Acceptance Test.",
+    "SPEOS_25_2_0_MIN_MAX: Maximal Speos supported version, Speos 25R2 Service Pack 0.",
+    "SPEOS_25_2_0_MIN_MIN: Minimal Speos required version, Speos 25R2 Service Pack 0.",
+    "SPEOS_25_1_0_MIN_MIN: Minimal Speos required version, Speos 25R1 Service Pack 0."
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,9 +149,9 @@ addopts = "-vvv --color=yes -ra --durations=25 --cov=ansys.speos --cov-report ht
 testpaths = ["tests"]
 markers = [
     "SPEOS_UAT: Supported on all Speos versions, User Acceptance Test.",
-    "SPEOS_25_2_0_MIN_MAX: Maximal Speos supported version, Speos 25R2 Service Pack 0.",
-    "SPEOS_25_2_0_MIN_MIN: Minimal Speos required version, Speos 25R2 Service Pack 0.",
-    "SPEOS_25_1_0_MIN_MIN: Minimal Speos required version, Speos 25R1 Service Pack 0."
+    "SPEOS_25_2_0_MAX: Maximal Speos supported version, Speos 25R2 Service Pack 0.",
+    "SPEOS_25_2_0_MIN: Minimal Speos required version, Speos 25R2 Service Pack 0.",
+    "SPEOS_25_1_0_MIN: Minimal Speos required version, Speos 25R1 Service Pack 0."
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,9 +149,7 @@ addopts = "-vvv --color=yes -ra --durations=25 --cov=ansys.speos --cov-report ht
 testpaths = ["tests"]
 markers = [
     "SPEOS_UAT: Supported on all Speos versions, User Acceptance Test.",
-    "SPEOS_25_2_0_MAX: Maximal Speos supported version, Speos 25R2 Service Pack 0.",
-    "SPEOS_25_2_0_MIN: Minimal Speos required version, Speos 25R2 Service Pack 0.",
-    "SPEOS_25_1_0_MIN: Minimal Speos required version, Speos 25R1 Service Pack 0."
+    "supported_speos_versions(min, max): Feature supported on respective Speos versions."
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,10 @@ show_missing = true
 minversion = "7.1"
 addopts = "-vvv --color=yes -ra --durations=25 --cov=ansys.speos --cov-report html:.cov/html --cov-report xml:.cov/xml --cov-report term"
 testpaths = ["tests"]
+markers = [
+    "SPEOS_25_2_0: Minimal required version Speos RPC 25R2 Service Pack 0.",
+    "SPEOS_25_1_0: Minimal required version Speos RPC 25R1 Service Pack 0."
+]
 
 [tool.mypy]
 python_version = "3.10"

--- a/tests/core/test_bsdf.py
+++ b/tests/core/test_bsdf.py
@@ -235,7 +235,7 @@ def compare_spectral_bsdf(bsdf1: SpectralBRDF, bsdf2: SpectralBRDF):
         return False
 
 
-@pytest.mark.SPEOS_25_1_0
+@pytest.mark.SPEOS_UAT
 def test_anisotropic_bsdf(speos: Speos):
     """Unit test for anisotropic bsdf class."""
     initial_bsdf = create_anisotropic_bsdf(speos)
@@ -292,7 +292,7 @@ def test_anisotropic_bsdf(speos: Speos):
     remove_file(str(bsdf_path3))
 
 
-@pytest.mark.SPEOS_25_1_0
+@pytest.mark.SPEOS_UAT
 def test_anisotropic_bsdf_interpolation_enhancement(speos: Speos):
     """Unit test for anisotropic bsdf interpolation class."""
     # test automatic interpolation enhancement
@@ -445,6 +445,7 @@ def test_anisotropic_bsdf_interpolation_enhancement(speos: Speos):
     assert interpolated_cons_transmission["0.0"]["0.0"]["height"] != 0.6
 
 
+@pytest.mark.SPEOS_UAT
 def test_bsdf180_creation(speos: Speos):
     """Unit test for create bsdf180 method."""
     input_file = Path(test_path) / "Gaussian Fresnel 10 deg.anisotropicbsdf"
@@ -458,6 +459,7 @@ def test_bsdf180_creation(speos: Speos):
     remove_file(str(output_file_2))
 
 
+@pytest.mark.SPEOS_UAT
 def test_spectral_brdf_creation(speos: Speos):
     """Unit test for create spectral brdf method."""
     input_file = [
@@ -475,6 +477,7 @@ def test_spectral_brdf_creation(speos: Speos):
     remove_file(str(output_file_2))
 
 
+@pytest.mark.SPEOS_UAT
 def test_anisotropic_bsdf_creation(speos: Speos):
     """Unit test for create anisotropic bsdf method."""
     input_file = [
@@ -493,6 +496,7 @@ def test_anisotropic_bsdf_creation(speos: Speos):
     remove_file(str(output_file_2))
 
 
+@pytest.mark.SPEOS_UAT
 def test_bsdf_error_management(speos: Speos):
     """Unit test of most bsdf error."""
     # BXDF datapoint class
@@ -552,6 +556,7 @@ def test_bsdf_error_management(speos: Speos):
         new_bsdf.transmission_spectrum = [[1, 2, 3], [1, 2]]
 
 
+@pytest.mark.SPEOS_UAT
 def test_spectral_brdf(speos: Speos):
     """Unit test for anisotropic bsdf class."""
     initial_bsdf = create_spectral_brdf(speos)
@@ -639,6 +644,7 @@ def test_spectral_brdf(speos: Speos):
     remove_file(str(bsdf_path5))
 
 
+@pytest.mark.SPEOS_UAT
 def test_spectral_bsdf_interpolation_enhancement(speos: Speos):
     """Unit test for anisotropic bsdf interpolation class."""
     # test automatic interpolation enhancement
@@ -784,6 +790,7 @@ def test_spectral_bsdf_interpolation_enhancement(speos: Speos):
     assert interpolated_cons_transmission["380.0"]["0.0"]["height"] != 0.6
 
 
+@pytest.mark.SPEOS_UAT
 def test_spectral_brdf_error_management(speos: Speos):
     """Unit test of most bsdf error."""
     # BXDF datapoint class

--- a/tests/core/test_bsdf.py
+++ b/tests/core/test_bsdf.py
@@ -235,6 +235,7 @@ def compare_spectral_bsdf(bsdf1: SpectralBRDF, bsdf2: SpectralBRDF):
         return False
 
 
+@pytest.mark.version("25.1.0")
 def test_anisotropic_bsdf(speos: Speos):
     """Unit test for anisotropic bsdf class."""
     initial_bsdf = create_anisotropic_bsdf(speos)
@@ -291,6 +292,7 @@ def test_anisotropic_bsdf(speos: Speos):
     remove_file(str(bsdf_path3))
 
 
+@pytest.mark.version("25.2.0")
 def test_anisotropic_bsdf_interpolation_enhancement(speos: Speos):
     """Unit test for anisotropic bsdf interpolation class."""
     # test automatic interpolation enhancement

--- a/tests/core/test_bsdf.py
+++ b/tests/core/test_bsdf.py
@@ -235,7 +235,7 @@ def compare_spectral_bsdf(bsdf1: SpectralBRDF, bsdf2: SpectralBRDF):
         return False
 
 
-@pytest.mark.version("25.1.0")
+@pytest.mark.SPEOS_25_1_0
 def test_anisotropic_bsdf(speos: Speos):
     """Unit test for anisotropic bsdf class."""
     initial_bsdf = create_anisotropic_bsdf(speos)
@@ -292,7 +292,7 @@ def test_anisotropic_bsdf(speos: Speos):
     remove_file(str(bsdf_path3))
 
 
-@pytest.mark.version("25.2.0")
+@pytest.mark.SPEOS_25_1_0
 def test_anisotropic_bsdf_interpolation_enhancement(speos: Speos):
     """Unit test for anisotropic bsdf interpolation class."""
     # test automatic interpolation enhancement

--- a/tests/core/test_intensity.py
+++ b/tests/core/test_intensity.py
@@ -30,7 +30,7 @@ from ansys.speos.core import GeoRef, Intensity, Speos
 from tests.conftest import test_path
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_create_intensity(speos: Speos):
     """Test creation of intensity."""
     # Default value
@@ -118,7 +118,7 @@ def test_create_intensity(speos: Speos):
     intensity1.delete()
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_switch_intensity(speos: Speos):
     """Test switch of intensity : from one with properties to one without.
 
@@ -137,7 +137,7 @@ def test_switch_intensity(speos: Speos):
     assert intensity1._intensity_properties.HasField("properties") is False
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_commit_intensity(speos: Speos):
     """Test commit of intensity."""
     # Create
@@ -155,7 +155,7 @@ def test_commit_intensity(speos: Speos):
     intensity1.delete()
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_reset_intensity(speos: Speos):
     """Test reset of intensity."""
     # Create + commit
@@ -177,7 +177,7 @@ def test_reset_intensity(speos: Speos):
     intensity1.delete()
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_library_modify_after_reset(speos: Speos):
     """Test modify library intensity feature after reset."""
     # Create + commit
@@ -216,7 +216,7 @@ def test_library_modify_after_reset(speos: Speos):
     intensity1.delete()
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_gaussian_modify_after_reset(speos: Speos):
     """Test modify gaussian intensity feature after reset."""
     # Create + commit
@@ -249,7 +249,7 @@ def test_gaussian_modify_after_reset(speos: Speos):
     ]
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_delete_intensity(speos: Speos):
     """Test delete of intensity."""
     # Create + commit

--- a/tests/core/test_intensity.py
+++ b/tests/core/test_intensity.py
@@ -24,10 +24,13 @@
 
 from pathlib import Path
 
+import pytest
+
 from ansys.speos.core import GeoRef, Intensity, Speos
 from tests.conftest import test_path
 
 
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_create_intensity(speos: Speos):
     """Test creation of intensity."""
     # Default value
@@ -66,7 +69,8 @@ def test_create_intensity(speos: Speos):
     assert len(intensity1._intensity_properties.library_properties.exit_geometries.geo_paths) == 1
     assert intensity1._intensity_properties.library_properties.HasField("normal_to_uv_map")
 
-    intensity1.set_library().set_exit_geometries()  # use default [] to reset exit geometries
+    # use default [] to reset exit geometries
+    intensity1.set_library().set_exit_geometries()
     intensity1.commit()
     assert intensity1._intensity_properties.library_properties.HasField("exit_geometries") is False
 
@@ -114,6 +118,7 @@ def test_create_intensity(speos: Speos):
     intensity1.delete()
 
 
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_switch_intensity(speos: Speos):
     """Test switch of intensity : from one with properties to one without.
 
@@ -132,6 +137,7 @@ def test_switch_intensity(speos: Speos):
     assert intensity1._intensity_properties.HasField("properties") is False
 
 
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_commit_intensity(speos: Speos):
     """Test commit of intensity."""
     # Create
@@ -149,6 +155,7 @@ def test_commit_intensity(speos: Speos):
     intensity1.delete()
 
 
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_reset_intensity(speos: Speos):
     """Test reset of intensity."""
     # Create + commit
@@ -170,6 +177,7 @@ def test_reset_intensity(speos: Speos):
     intensity1.delete()
 
 
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_library_modify_after_reset(speos: Speos):
     """Test modify library intensity feature after reset."""
     # Create + commit
@@ -208,6 +216,7 @@ def test_library_modify_after_reset(speos: Speos):
     intensity1.delete()
 
 
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_gaussian_modify_after_reset(speos: Speos):
     """Test modify gaussian intensity feature after reset."""
     # Create + commit
@@ -240,6 +249,7 @@ def test_gaussian_modify_after_reset(speos: Speos):
     ]
 
 
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_delete_intensity(speos: Speos):
     """Test delete of intensity."""
     # Create + commit

--- a/tests/core/test_launcher.py
+++ b/tests/core/test_launcher.py
@@ -39,6 +39,7 @@ IS_DOCKER = config.get("SpeosServerOnDocker")
 
 
 @pytest.mark.skipif(IS_DOCKER, reason="launcher only works without Docker image")
+@pytest.mark.SPEOS_UAT
 def test_local_session(*args):
     """Test local session launch and close."""
     port = config.get("SpeosServerPort") + 1
@@ -62,6 +63,7 @@ def test_local_session(*args):
 
 @patch.object(subprocess, "Popen")
 @patch.object(subprocess, "run")
+@pytest.mark.SPEOS_UAT
 def test_coverage_launcher_speosdocker(*args):
     """Test local session launch on remote server to improve coverage."""
     port = config.get("SpeosServerPort")

--- a/tests/core/test_lxp.py
+++ b/tests/core/test_lxp.py
@@ -24,12 +24,15 @@
 
 from pathlib import Path
 
+import pytest
+
 import ansys.speos.core.lxp as lxp
 from ansys.speos.core.project import Project
 from ansys.speos.core.speos import Speos
 from tests.conftest import IMAGE_RESULTS_DIR, test_path
 
 
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_light_path_finder_direct(speos: Speos):
     """Test for direct simulation lpf."""
     path = str(Path(test_path) / "basic_DirectSimu.lpf")
@@ -57,7 +60,8 @@ def test_light_path_finder_direct(speos: Speos):
     }
     assert lpf.nb_traces == 24817
     assert lpf.nb_xmps == 3
-    assert lpf.has_sensor_contributions is False  # No contributions stored in Direct simu
+    # No contributions stored in Direct simu
+    assert lpf.has_sensor_contributions is False
     assert len(lpf.sensor_names) == 3
     assert lpf.sensor_names[0] == "Irradiance Sensor (0)"
     assert lpf.sensor_names[2] == "Irradiance Sensor (2)"
@@ -70,6 +74,7 @@ def test_light_path_finder_direct(speos: Speos):
     assert lpf.rays[50].get() == expected_ray
 
 
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_light_path_finder_inverse(speos: Speos):
     """Test for inverse simulation lpf."""
     path = str(Path(test_path) / "basic_InverseSimu.lpf")
@@ -116,7 +121,8 @@ def test_light_path_finder_inverse(speos: Speos):
 
     assert lpf.nb_traces == 21044
     assert lpf.nb_xmps == 1
-    assert lpf.has_sensor_contributions is True  # No contributions stored in Direct simu
+    # No contributions stored in Direct simu
+    assert lpf.has_sensor_contributions is True
     assert len(lpf.sensor_names) == 1
     assert lpf.sensor_names[0] == "Camera_Perfect_Lens_System_V2:3"
     lpf.filter_by_body_ids([3744252339])
@@ -128,6 +134,7 @@ def test_light_path_finder_inverse(speos: Speos):
     assert lpf.rays[50].get() == expected_ray
 
 
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_lpf_preview_with_project(speos: Speos):
     """Test for visualizing lpf data."""
     path = str(Path(test_path) / "basic_DirectSimu.lpf")
@@ -144,6 +151,7 @@ def test_lpf_preview_with_project(speos: Speos):
     assert screenshot.stat().st_size > 0
 
 
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_lpf_preview_without_project(speos: Speos):
     """Test for visualizing lpf data."""
     path = str(Path(test_path) / "basic_DirectSimu.lpf")

--- a/tests/core/test_lxp.py
+++ b/tests/core/test_lxp.py
@@ -32,7 +32,7 @@ from ansys.speos.core.speos import Speos
 from tests.conftest import IMAGE_RESULTS_DIR, test_path
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_light_path_finder_direct(speos: Speos):
     """Test for direct simulation lpf."""
     path = str(Path(test_path) / "basic_DirectSimu.lpf")
@@ -74,7 +74,7 @@ def test_light_path_finder_direct(speos: Speos):
     assert lpf.rays[50].get() == expected_ray
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_light_path_finder_inverse(speos: Speos):
     """Test for inverse simulation lpf."""
     path = str(Path(test_path) / "basic_InverseSimu.lpf")
@@ -134,7 +134,7 @@ def test_light_path_finder_inverse(speos: Speos):
     assert lpf.rays[50].get() == expected_ray
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_lpf_preview_with_project(speos: Speos):
     """Test for visualizing lpf data."""
     path = str(Path(test_path) / "basic_DirectSimu.lpf")
@@ -151,7 +151,7 @@ def test_lpf_preview_with_project(speos: Speos):
     assert screenshot.stat().st_size > 0
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_lpf_preview_without_project(speos: Speos):
     """Test for visualizing lpf data."""
     path = str(Path(test_path) / "basic_DirectSimu.lpf")

--- a/tests/core/test_opt_prop.py
+++ b/tests/core/test_opt_prop.py
@@ -24,10 +24,13 @@
 
 from pathlib import Path
 
+import pytest
+
 from ansys.speos.core import GeoRef, Project, Speos
 from tests.conftest import test_path
 
 
+@pytest.mark.SPEOS_UAT
 def test_create_optical_property(speos: Speos):
     """Test creation of optical property."""
     p = Project(speos=speos)
@@ -116,6 +119,7 @@ def test_create_optical_property(speos: Speos):
     op1.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_commit_optical_property(speos: Speos):
     """Test commit of optical property."""
     p = Project(speos=speos)
@@ -142,6 +146,7 @@ def test_commit_optical_property(speos: Speos):
     op1.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_reset_optical_property(speos: Speos):
     """Test reset of optical property."""
     p = Project(speos=speos)
@@ -191,6 +196,7 @@ def test_reset_optical_property(speos: Speos):
     op1.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_delete_optical_property(speos: Speos):
     """Test delete of optical property."""
     p = Project(speos=speos)
@@ -230,6 +236,7 @@ def test_delete_optical_property(speos: Speos):
     assert op1._material_instance.HasField("geometries")  # local
 
 
+@pytest.mark.SPEOS_UAT
 def test_get_optical_property(speos: Speos, capsys):
     """Test get of an optical property."""
     p = Project(speos=speos)

--- a/tests/core/test_part.py
+++ b/tests/core/test_part.py
@@ -22,9 +22,12 @@
 
 """Test basic using part/body/face."""
 
+import pytest
+
 from ansys.speos.core import Project, Speos
 
 
+@pytest.mark.SPEOS_UAT
 def test_create_root_part(speos: Speos):
     """Test create root part in project."""
     # Create an empty project
@@ -40,6 +43,7 @@ def test_create_root_part(speos: Speos):
     assert len(root_part.part_link.get().parts) == 0
 
 
+@pytest.mark.SPEOS_UAT
 def test_create_body(speos: Speos):
     """Test create bodies in root part."""
     # Create an empty project with a root part
@@ -69,6 +73,7 @@ def test_create_body(speos: Speos):
     assert len(root_part.part_link.get().body_guids) == 0
 
 
+@pytest.mark.SPEOS_UAT
 def test_create_face(speos: Speos):
     """Test create faces in body."""
     # Create an empty project with a root part containing a body
@@ -124,6 +129,7 @@ def test_create_face(speos: Speos):
     assert len(body1.body_link.get().face_guids) == 0
 
 
+@pytest.mark.SPEOS_UAT
 def test_create_subpart(speos: Speos):
     """Test create sub part in root part."""
     # Create an empty project with a root part
@@ -209,6 +215,7 @@ def test_create_subpart(speos: Speos):
     assert len(root_part.part_link.get().parts) == 0
 
 
+@pytest.mark.SPEOS_UAT
 def test_create_subpart_body(speos: Speos):
     """Test create body in sub part."""
     # Create an empty project with a root part and sub part
@@ -243,6 +250,7 @@ def test_create_subpart_body(speos: Speos):
     assert len(sp1.part_link.get().body_guids) == 0
 
 
+@pytest.mark.SPEOS_UAT
 def test_create_subpart_subpart(speos: Speos):
     """Test create sub part in sub part."""
     # Create an empty project with a root part and sub part
@@ -321,6 +329,7 @@ def test_create_subpart_subpart(speos: Speos):
     assert len(sp1.part_link.get().parts) == 0
 
 
+@pytest.mark.SPEOS_UAT
 def test_commit_part(speos: Speos):
     """Test commit of part."""
     p = Project(speos=speos)
@@ -355,6 +364,7 @@ def test_commit_part(speos: Speos):
     root_part.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_reset_part(speos: Speos):
     """Test reset of part."""
     p = Project(speos=speos)
@@ -385,6 +395,7 @@ def test_reset_part(speos: Speos):
     root_part.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_delete_part(speos: Speos):
     """Test delete of part."""
     p = Project(speos=speos)

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -24,6 +24,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from ansys.speos.core import Body, Face, GeoRef, Part, Project, Speos
 from ansys.speos.core.opt_prop import OptProp
 from ansys.speos.core.sensor import Sensor3DIrradiance, SensorIrradiance, SensorRadiance
@@ -32,6 +34,7 @@ from ansys.speos.core.source import SourceLuminaire, SourceRayFile, SourceSurfac
 from tests.conftest import test_path
 
 
+@pytest.mark.SPEOS_UAT
 def test_find_feature(speos: Speos):
     """Test find a feature in project."""
     # Create an empty project
@@ -113,6 +116,7 @@ def test_find_feature(speos: Speos):
     assert features[0] == sensor3
 
 
+@pytest.mark.SPEOS_UAT
 def test_find_feature_geom(speos: Speos):
     """Test find a geometry feature in project loaded from speos file."""
     # Create a project from a file
@@ -242,6 +246,7 @@ def test_find_feature_geom(speos: Speos):
     assert found_feats[1] == face_112
 
 
+@pytest.mark.SPEOS_UAT
 def test_find_after_load(speos: Speos):
     """Test find feature in project loaded from speos file."""
     # Create a project from a file
@@ -269,6 +274,7 @@ def test_find_after_load(speos: Speos):
     assert sim_feats[0]._name == "ASSEMBLY1.DS (0)"
 
 
+@pytest.mark.SPEOS_UAT
 def test_create_root_part_after_load(speos: Speos):
     """Test create_root_part feature in project loaded from speos file."""
     # Create a project from a file
@@ -290,6 +296,7 @@ def test_create_root_part_after_load(speos: Speos):
     assert rp is rp2
 
 
+@pytest.mark.SPEOS_UAT
 def test_delete(speos: Speos):
     """Test delete a project."""
     # Create an empty project
@@ -314,6 +321,7 @@ def test_delete(speos: Speos):
     assert len(p._features) == 0
 
 
+@pytest.mark.SPEOS_UAT
 def test_from_file(speos: Speos):
     """Test create a project from file."""
     # Create a project from a file
@@ -376,6 +384,7 @@ def test_from_file(speos: Speos):
     assert ssr_data.irradiance_sensor_template.dimensions.x_sampling == 500
 
 
+@pytest.mark.SPEOS_UAT
 def test_from_file_threads_limited(speos: Speos):
     """Test change Number of threads used."""
     # Create a project from a file
@@ -401,6 +410,7 @@ def test_from_file_threads_limited(speos: Speos):
     ] == "int::" + str(threads_nb)
 
 
+@pytest.mark.SPEOS_UAT
 def test_find_geom(speos: Speos):
     """Test find geometry feature in a project."""
     # Create a project from a file
@@ -452,6 +462,7 @@ def test_find_geom(speos: Speos):
     assert len(all_faces) == 11
 
 
+@pytest.mark.SPEOS_UAT
 def test_preview_visual_data(speos: Speos):
     """Test preview visualization data inside a project."""
     # preview irradiance sensor data

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -462,7 +462,7 @@ def test_find_geom(speos: Speos):
     assert len(all_faces) == 11
 
 
-@pytest.mark.SPEOS_UAT
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_preview_visual_data(speos: Speos):
     """Test preview visualization data inside a project."""
     # preview irradiance sensor data

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -462,7 +462,7 @@ def test_find_geom(speos: Speos):
     assert len(all_faces) == 11
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_preview_visual_data(speos: Speos):
     """Test preview visualization data inside a project."""
     # preview irradiance sensor data

--- a/tests/core/test_proto_message_utils.py
+++ b/tests/core/test_proto_message_utils.py
@@ -24,6 +24,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from ansys.speos.core import GeoRef, OptProp, Project, Speos, proto_message_utils
 from ansys.speos.core.kernel import scene
 from ansys.speos.core.kernel.proto_message_utils import protobuf_message_to_dict
@@ -32,6 +34,7 @@ from ansys.speos.core.source import SourceSurface
 from tests.conftest import test_path
 
 
+@pytest.mark.SPEOS_UAT
 def test_replace_guid_elt(speos: Speos):
     """Test _replace_guid_elt."""
     # Example with surface source : spectrum guid + intensity guid
@@ -81,6 +84,7 @@ def test_replace_guid_elt(speos: Speos):
     assert find[0][1]["name"] == "Surface.1.Spectrum"
 
 
+@pytest.mark.SPEOS_UAT
 def test_replace_guid_elt_ignore_simple_key(speos: Speos):
     """Test _replace_guid_elt with parameter ignore_simple_key."""
     # Example with surface source : spectrum guid + intensity guid
@@ -118,6 +122,7 @@ def test_replace_guid_elt_ignore_simple_key(speos: Speos):
     assert proto_message_utils._finder_by_key(dict_var=src_t_dict, key="intensity") == []
 
 
+@pytest.mark.SPEOS_UAT
 def test_replace_guid_elt_list(speos: Speos):
     """Test _replace_guid_elt in a specific case : list of guids like sop_guids (before v252.1)."""
     # Example with material : vop guid + sop guids
@@ -182,6 +187,7 @@ def test_replace_guid_elt_list(speos: Speos):
         assert find[0][1]["reflectance"] == 100.0
 
 
+@pytest.mark.SPEOS_UAT
 def test_replace_guid_elt_complex(speos: Speos):
     """Test _replace_guid_elt in a bigger message like scene."""
     scene_link = speos.client.scenes().create(message=scene.ProtoScene())
@@ -256,6 +262,7 @@ def test_replace_guid_elt_complex(speos: Speos):
         assert len(find) == 3
 
 
+@pytest.mark.SPEOS_UAT
 def test_value_finder_key_startswith(speos: Speos):
     """Test _value_finder_key_startswith."""
     p = Project(speos=speos)
@@ -285,6 +292,7 @@ def test_value_finder_key_startswith(speos: Speos):
     assert keys == ["surface_properties"]
 
 
+@pytest.mark.SPEOS_UAT
 def test__value_finder_key_endswith(speos: Speos):
     """Test _value_finder_key_endswith."""
     p = Project(speos=speos)
@@ -318,6 +326,7 @@ def test__value_finder_key_endswith(speos: Speos):
     ]
 
 
+@pytest.mark.SPEOS_UAT
 def test_replace_properties(speos: Speos):
     """Test _replace_properties."""
     p = Project(speos=speos)
@@ -363,6 +372,7 @@ def test_replace_properties(speos: Speos):
     assert find[0][0] == ".source.surface.exitance_constant.geo_paths"
 
 
+@pytest.mark.SPEOS_UAT
 def test_replace_special_props(speos: Speos):
     """Test _replace_properties with a property that shouldn't be replaced."""
     p = Project(speos=speos)
@@ -385,6 +395,7 @@ def test_replace_special_props(speos: Speos):
     assert find[0][0] == ".lxp_properties.nb_max_paths"
 
 
+@pytest.mark.SPEOS_UAT
 def test_finder_by_key(speos: Speos):
     """Test _finder_by_key."""
     p = Project(
@@ -434,6 +445,7 @@ def test_finder_by_key(speos: Speos):
     assert res[1][1] == "Solid Body in SOURCE1:2494956811/Face in SOURCE1:187"
 
 
+@pytest.mark.SPEOS_UAT
 def test_flatten_dict(speos: Speos):
     """proto_message_utils test of '_flatten_dict' method."""
     p = Project(

--- a/tests/core/test_sensor.py
+++ b/tests/core/test_sensor.py
@@ -39,7 +39,7 @@ from ansys.speos.core.simulation import SimulationDirect
 from tests.conftest import test_path
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_create_camera_sensor(speos: Speos):
     """Test creation of camera sensor."""
     p = Project(speos=speos)

--- a/tests/core/test_sensor.py
+++ b/tests/core/test_sensor.py
@@ -39,7 +39,7 @@ from ansys.speos.core.simulation import SimulationDirect
 from tests.conftest import test_path
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_create_camera_sensor(speos: Speos):
     """Test creation of camera sensor."""
     p = Project(speos=speos)
@@ -424,7 +424,7 @@ def test_create_camera_sensor(speos: Speos):
     sensor1.delete()
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.supported_speos_versions(min=251)
 def test_create_irradiance_sensor(speos: Speos):
     """Test creation of irradiance sensor."""
     p = Project(speos=speos)
@@ -717,7 +717,7 @@ def test_create_irradiance_sensor(speos: Speos):
     sensor1.delete()
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_create_radiance_sensor(speos: Speos):
     """Test creation of radiance sensor."""
     p = Project(speos=speos)
@@ -953,7 +953,7 @@ def test_create_radiance_sensor(speos: Speos):
     assert radiance_properties.HasField("layer_type_none")
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_load_3d_irradiance_sensor(speos: Speos):
     """Test load of 3d irradiance sensor."""
     p = Project(
@@ -964,7 +964,7 @@ def test_load_3d_irradiance_sensor(speos: Speos):
     assert sensor_3d is not None
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_create_3d_irradiance_sensor(speos: Speos):
     """Test creation of 3d irradiance sensor."""
     p = Project(
@@ -1242,7 +1242,7 @@ def test_reset_sensor(speos: Speos):
     sensor1.delete()
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.supported_speos_versions(min=251)
 def test_irradiance_modify_after_reset(speos: Speos):
     """Test reset of irradiance sensor, and then modify."""
     p = Project(speos=speos)
@@ -1321,7 +1321,7 @@ def test_irradiance_modify_after_reset(speos: Speos):
     sensor1.delete()
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_radiance_modify_after_reset(speos: Speos):
     """Test reset of radiance sensor, and then modify."""
     p = Project(speos=speos)
@@ -1400,7 +1400,7 @@ def test_radiance_modify_after_reset(speos: Speos):
     sensor1.delete()
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.supported_speos_versions(min=251)
 def test_camera_modify_after_reset(speos: Speos):
     """Test reset of camera sensor, and then modify."""
     p = Project(speos=speos)

--- a/tests/core/test_sensor.py
+++ b/tests/core/test_sensor.py
@@ -25,6 +25,8 @@
 import math
 from pathlib import Path
 
+import pytest
+
 from ansys.api.speos.sensor.v1 import camera_sensor_pb2
 from ansys.speos.core import Body, GeoRef, Project, Speos, sensor
 from ansys.speos.core.sensor import (
@@ -37,6 +39,7 @@ from ansys.speos.core.simulation import SimulationDirect
 from tests.conftest import test_path
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_create_camera_sensor(speos: Speos):
     """Test creation of camera sensor."""
     p = Project(speos=speos)
@@ -421,6 +424,7 @@ def test_create_camera_sensor(speos: Speos):
     sensor1.delete()
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_create_irradiance_sensor(speos: Speos):
     """Test creation of irradiance sensor."""
     p = Project(speos=speos)
@@ -713,6 +717,7 @@ def test_create_irradiance_sensor(speos: Speos):
     sensor1.delete()
 
 
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_create_radiance_sensor(speos: Speos):
     """Test creation of radiance sensor."""
     p = Project(speos=speos)
@@ -875,7 +880,8 @@ def test_create_radiance_sensor(speos: Speos):
         50,
     ]
 
-    sensor1.set_observer_point(value=None)  # cancel observer point chosen previously
+    # cancel observer point chosen previously
+    sensor1.set_observer_point(value=None)
     sensor1.commit()
     assert radiance_properties.observer_point == []
 
@@ -947,6 +953,7 @@ def test_create_radiance_sensor(speos: Speos):
     assert radiance_properties.HasField("layer_type_none")
 
 
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_load_3d_irradiance_sensor(speos: Speos):
     """Test load of 3d irradiance sensor."""
     p = Project(
@@ -957,6 +964,7 @@ def test_load_3d_irradiance_sensor(speos: Speos):
     assert sensor_3d is not None
 
 
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_create_3d_irradiance_sensor(speos: Speos):
     """Test creation of 3d irradiance sensor."""
     p = Project(
@@ -1096,6 +1104,7 @@ def test_create_3d_irradiance_sensor(speos: Speos):
     sim.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_commit_sensor(speos: Speos):
     """Test commit of sensor."""
     p = Project(speos=speos)
@@ -1119,6 +1128,7 @@ def test_commit_sensor(speos: Speos):
     sensor1.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_reset_sensor(speos: Speos):
     """Test reset of sensor."""
     p = Project(speos=speos)
@@ -1232,6 +1242,7 @@ def test_reset_sensor(speos: Speos):
     sensor1.delete()
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_irradiance_modify_after_reset(speos: Speos):
     """Test reset of irradiance sensor, and then modify."""
     p = Project(speos=speos)
@@ -1310,6 +1321,7 @@ def test_irradiance_modify_after_reset(speos: Speos):
     sensor1.delete()
 
 
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_radiance_modify_after_reset(speos: Speos):
     """Test reset of radiance sensor, and then modify."""
     p = Project(speos=speos)
@@ -1344,7 +1356,7 @@ def test_radiance_modify_after_reset(speos: Speos):
     sensor1.set_dimensions().set_x_start(-100)
     assert sensor1._sensor_template.radiance_sensor_template.dimensions.x_start == -100
 
-    ## Props
+    # Props
     assert sensor1._sensor_instance.radiance_properties.axis_system == [
         0,
         0,
@@ -1388,6 +1400,7 @@ def test_radiance_modify_after_reset(speos: Speos):
     sensor1.delete()
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_camera_modify_after_reset(speos: Speos):
     """Test reset of camera sensor, and then modify."""
     p = Project(speos=speos)
@@ -1473,6 +1486,7 @@ def test_camera_modify_after_reset(speos: Speos):
     sensor1.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_delete_sensor(speos: Speos):
     """Test delete of sensor."""
     p = Project(speos=speos)
@@ -1498,6 +1512,7 @@ def test_delete_sensor(speos: Speos):
     assert sensor1._sensor_instance.HasField("irradiance_properties")  # local
 
 
+@pytest.mark.SPEOS_UAT
 def test_get_sensor(speos: Speos, capsys):
     """Test get of a sensor."""
     p = Project(speos=speos)

--- a/tests/core/test_simulation.py
+++ b/tests/core/test_simulation.py
@@ -41,6 +41,7 @@ from tests.helper import does_file_exist, remove_file
 IS_DOCKER = config.get("SpeosServerOnDocker")
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_create_direct(speos: Speos):
     """Test creation of Direct Simulation."""
     p = Project(speos=speos)
@@ -135,6 +136,7 @@ def test_create_direct(speos: Speos):
     sim1.delete()
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_create_inverse(speos: Speos):
     """Test creation of Inverse Simulation."""
     p = Project(speos=speos)
@@ -253,6 +255,7 @@ def test_create_inverse(speos: Speos):
     sim1.delete()
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_create_interactive(speos: Speos):
     """Test creation of Interactive Simulation."""
     p = Project(speos=speos)
@@ -366,6 +369,7 @@ def test_create_interactive(speos: Speos):
     sim1.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_commit(speos: Speos):
     """Test commit of simulation."""
     p = Project(speos=speos)
@@ -420,6 +424,7 @@ def test_commit(speos: Speos):
     sim1.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_reset(speos: Speos):
     """Test reset of simulation."""
     p = Project(speos=speos)
@@ -474,6 +479,7 @@ def test_reset(speos: Speos):
     sim1.delete()
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_direct_modify_after_reset(speos: Speos):
     """Test reset of direct simulation, and then modify."""
     p = Project(speos=speos)
@@ -544,6 +550,7 @@ def test_direct_modify_after_reset(speos: Speos):
     p.delete()
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_inverse_modify_after_reset(speos: Speos):
     """Test reset of inverse simulation, and then modify."""
     p = Project(speos=speos)
@@ -620,6 +627,7 @@ def test_inverse_modify_after_reset(speos: Speos):
     p.delete()
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_interactive_modify_after_reset(speos: Speos):
     """Test reset of interactive simulation, and then modify."""
     p = Project(speos=speos)
@@ -676,6 +684,7 @@ def test_interactive_modify_after_reset(speos: Speos):
     p.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_delete(speos: Speos):
     """Test delete of simulation."""
     p = Project(speos=speos)
@@ -725,6 +734,7 @@ def test_delete(speos: Speos):
     assert len(sim1._simulation_instance.sensor_paths) == 1  # local
 
 
+@pytest.mark.SPEOS_UAT
 def test_get_simulation(speos: Speos, capsys):
     """Test get of a simulation."""
     p = Project(speos=speos)
@@ -754,6 +764,7 @@ def test_get_simulation(speos: Speos, capsys):
     assert "Used key: geometry not found in key list" in stdout
 
 
+@pytest.mark.SPEOS_UAT
 def test_export(speos: Speos):
     """Test export of simulation."""
     p = Project(
@@ -784,6 +795,7 @@ def test_export(speos: Speos):
 
 
 @pytest.mark.skipif(IS_DOCKER, reason="COM API is only available locally")
+@pytest.mark.SPEOS_UAT
 def test_export_vtp(speos: Speos):
     """Test export of xm3 and xmp as vtp files."""
     import numpy as np
@@ -797,7 +809,7 @@ def test_export_vtp(speos: Speos):
     )
     sim = p.find(name=".*", name_regex=True, feature_type=SimulationDirect)[0]
 
-    ## ==== test 3d sensor photometric ===
+    # ==== test 3d sensor photometric ===
     # verify illuminance, reflection, transmission, absorption are saved in vtp
     # verify the vtp data is same as calculated
     sensor_3d = p.find(name=".*", name_regex=True, feature_type=Sensor3DIrradiance)[0]
@@ -881,7 +893,7 @@ def test_export_vtp(speos: Speos):
         )
     )
 
-    ## === test 3d sensor photometric with radial integration ===
+    # === test 3d sensor photometric with radial integration ===
     # only illuminance value is saved in vtp file
     p2 = Project(
         speos=speos,
@@ -902,7 +914,7 @@ def test_export_vtp(speos: Speos):
     assert np.allclose(vtp_data.get("Transmission"), 0.0) is True
     assert np.allclose(vtp_data.get("Absorption"), 0.0) is True
 
-    ## ===  test 3d sensor radiometric ===
+    # ===  test 3d sensor radiometric ===
     # only irradiance, reflection, transmission, absorption value is saved in vtp file
     # verify the vtp results are the same as calculated ones.
     p3 = Project(
@@ -1077,7 +1089,7 @@ def test_export_vtp(speos: Speos):
         )
     )
 
-    ## === test irradiance xmp radiometric ===
+    # === test irradiance xmp radiometric ===
     # verify the result is radiometric
     p6 = Project(
         speos=speos,
@@ -1094,7 +1106,7 @@ def test_export_vtp(speos: Speos):
     vtp_data = pv.read(vtp_results[0]).point_data
     assert np.allclose(vtp_data.get("Radiometric"), 0.0) is not True
 
-    ## === test irradiance colorimetric ===
+    # === test irradiance colorimetric ===
     # verify it has x, photometric, radiometric, z value in vtp file
     p7 = Project(
         speos=speos,
@@ -1115,7 +1127,7 @@ def test_export_vtp(speos: Speos):
     assert np.allclose(vtp_data.get("Radiometric"), 0.0) is not True
     assert np.allclose(vtp_data.get("Z"), 0.0) is not True
 
-    ## === test irradiance spectral ===
+    # === test irradiance spectral ===
     # verify it has x, photometric, radiometric, z value in vtp file
     # verify the summing up per spectral layer
     p8 = Project(

--- a/tests/core/test_simulation.py
+++ b/tests/core/test_simulation.py
@@ -41,7 +41,7 @@ from tests.helper import does_file_exist, remove_file
 IS_DOCKER = config.get("SpeosServerOnDocker")
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.supported_speos_versions(min=251)
 def test_create_direct(speos: Speos):
     """Test creation of Direct Simulation."""
     p = Project(speos=speos)
@@ -136,7 +136,7 @@ def test_create_direct(speos: Speos):
     sim1.delete()
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.supported_speos_versions(min=251)
 def test_create_inverse(speos: Speos):
     """Test creation of Inverse Simulation."""
     p = Project(speos=speos)
@@ -255,7 +255,7 @@ def test_create_inverse(speos: Speos):
     sim1.delete()
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.supported_speos_versions(min=251)
 def test_create_interactive(speos: Speos):
     """Test creation of Interactive Simulation."""
     p = Project(speos=speos)
@@ -479,7 +479,7 @@ def test_reset(speos: Speos):
     sim1.delete()
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.supported_speos_versions(min=251)
 def test_direct_modify_after_reset(speos: Speos):
     """Test reset of direct simulation, and then modify."""
     p = Project(speos=speos)
@@ -550,7 +550,7 @@ def test_direct_modify_after_reset(speos: Speos):
     p.delete()
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.supported_speos_versions(min=251)
 def test_inverse_modify_after_reset(speos: Speos):
     """Test reset of inverse simulation, and then modify."""
     p = Project(speos=speos)
@@ -627,7 +627,7 @@ def test_inverse_modify_after_reset(speos: Speos):
     p.delete()
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.supported_speos_versions(min=251)
 def test_interactive_modify_after_reset(speos: Speos):
     """Test reset of interactive simulation, and then modify."""
     p = Project(speos=speos)

--- a/tests/core/test_source.py
+++ b/tests/core/test_source.py
@@ -25,6 +25,8 @@
 import datetime
 from pathlib import Path
 
+import pytest
+
 from ansys.speos.core import GeoRef, Project, Speos
 from ansys.speos.core.source import (
     SourceAmbientNaturalLight,
@@ -35,6 +37,7 @@ from ansys.speos.core.source import (
 from tests.conftest import test_path
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_create_luminaire_source(speos: Speos):
     """Test creation of luminaire source."""
     p = Project(speos=speos)
@@ -133,6 +136,7 @@ def test_create_luminaire_source(speos: Speos):
     assert len(p.scene_link.get().sources) == 0
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_create_surface_source(speos: Speos):
     """Test creation of surface source."""
     p = Project(speos=speos)
@@ -263,6 +267,7 @@ def test_create_surface_source(speos: Speos):
     source1.delete()
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_create_rayfile_source(speos: Speos):
     """Test creation of ray file."""
     p = Project(speos=speos)
@@ -369,6 +374,7 @@ def test_create_rayfile_source(speos: Speos):
     source1.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_create_natural_light_source(speos: Speos):
     """Test creation of ambient natural light source."""
     p = Project(speos=speos)
@@ -525,6 +531,7 @@ def test_create_natural_light_source(speos: Speos):
     source2.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_keep_same_internal_feature(speos: Speos):
     """Test regarding source internal features (like spectrum, intensity).
 
@@ -586,6 +593,7 @@ def test_keep_same_internal_feature(speos: Speos):
     source3.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_commit_source(speos: Speos):
     """Test commit of source."""
     p = Project(speos=speos)
@@ -610,6 +618,7 @@ def test_commit_source(speos: Speos):
     source1.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_reset_source(speos: Speos):
     """Test reset of a source."""
     p = Project(speos=speos)
@@ -647,6 +656,7 @@ def test_reset_source(speos: Speos):
     source1.delete()
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_luminaire_modify_after_reset(speos: Speos):
     """Test reset of luminaire source, and then modify."""
     p = Project(speos=speos)
@@ -706,6 +716,7 @@ def test_luminaire_modify_after_reset(speos: Speos):
     source.delete()
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_rayfile_modify_after_reset(speos: Speos):
     """Test reset of ray file source, and then modify."""
     p = Project(speos=speos)
@@ -765,6 +776,7 @@ def test_rayfile_modify_after_reset(speos: Speos):
     source.delete()
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_surface_modify_after_reset(speos: Speos):
     """Test reset of surface source, and then modify."""
     p = Project(speos=speos)
@@ -824,6 +836,7 @@ def test_surface_modify_after_reset(speos: Speos):
     source.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_delete_source(speos: Speos):
     """Test delete of source."""
     p = Project(speos=speos)
@@ -851,6 +864,7 @@ def test_delete_source(speos: Speos):
     assert source1._source_instance.HasField("rayfile_properties")  # local
 
 
+@pytest.mark.SPEOS_UAT
 def test_print_source(speos: Speos):
     """Test delete of source."""
     p = Project(speos=speos)
@@ -918,6 +932,7 @@ def test_print_source(speos: Speos):
     source.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_get_source(speos: Speos, capsys):
     """Test get method of the source class."""
     p = Project(speos=speos)

--- a/tests/core/test_source.py
+++ b/tests/core/test_source.py
@@ -37,7 +37,7 @@ from ansys.speos.core.source import (
 from tests.conftest import test_path
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.supported_speos_versions(min=251)
 def test_create_luminaire_source(speos: Speos):
     """Test creation of luminaire source."""
     p = Project(speos=speos)
@@ -136,7 +136,7 @@ def test_create_luminaire_source(speos: Speos):
     assert len(p.scene_link.get().sources) == 0
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.supported_speos_versions(min=251)
 def test_create_surface_source(speos: Speos):
     """Test creation of surface source."""
     p = Project(speos=speos)
@@ -267,7 +267,7 @@ def test_create_surface_source(speos: Speos):
     source1.delete()
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.supported_speos_versions(min=251)
 def test_create_rayfile_source(speos: Speos):
     """Test creation of ray file."""
     p = Project(speos=speos)
@@ -374,7 +374,7 @@ def test_create_rayfile_source(speos: Speos):
     source1.delete()
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_create_natural_light_source(speos: Speos):
     """Test creation of ambient natural light source."""
     p = Project(speos=speos)
@@ -656,7 +656,7 @@ def test_reset_source(speos: Speos):
     source1.delete()
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.supported_speos_versions(min=251)
 def test_luminaire_modify_after_reset(speos: Speos):
     """Test reset of luminaire source, and then modify."""
     p = Project(speos=speos)
@@ -716,7 +716,7 @@ def test_luminaire_modify_after_reset(speos: Speos):
     source.delete()
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.supported_speos_versions(min=251)
 def test_rayfile_modify_after_reset(speos: Speos):
     """Test reset of ray file source, and then modify."""
     p = Project(speos=speos)
@@ -776,7 +776,7 @@ def test_rayfile_modify_after_reset(speos: Speos):
     source.delete()
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.supported_speos_versions(min=251)
 def test_surface_modify_after_reset(speos: Speos):
     """Test reset of surface source, and then modify."""
     p = Project(speos=speos)

--- a/tests/core/test_source.py
+++ b/tests/core/test_source.py
@@ -374,7 +374,7 @@ def test_create_rayfile_source(speos: Speos):
     source1.delete()
 
 
-@pytest.mark.SPEOS_UAT
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_create_natural_light_source(speos: Speos):
     """Test creation of ambient natural light source."""
     p = Project(speos=speos)

--- a/tests/core/test_spectrum.py
+++ b/tests/core/test_spectrum.py
@@ -24,10 +24,13 @@
 
 from pathlib import Path
 
+import pytest
+
 from ansys.speos.core import Spectrum, Speos
 from tests.conftest import test_path
 
 
+@pytest.mark.SPEOS_UAT
 def test_create_spectrum(speos: Speos):
     """Test creation of spectrum."""
     # Default value
@@ -90,6 +93,7 @@ def test_create_spectrum(speos: Speos):
     spectrum1.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_commit_spectrum(speos: Speos):
     """Test commit of spectrum."""
     # Create
@@ -105,6 +109,7 @@ def test_commit_spectrum(speos: Speos):
     spectrum1.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_reset_spectrum(speos: Speos):
     """Test reset of spectrum."""
     # Create + commit
@@ -125,6 +130,7 @@ def test_reset_spectrum(speos: Speos):
     spectrum1.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_delete_spectrum(speos: Speos):
     """Test delete of spectrum."""
     # Create + commit

--- a/tests/kernel/test_client.py
+++ b/tests/kernel/test_client.py
@@ -23,17 +23,20 @@
 """Test basic client connection."""
 
 from grpc import insecure_channel
+import pytest
 
 from ansys.speos.core.kernel.client import SpeosClient
 from ansys.speos.core.speos import Speos
 from tests.conftest import config
 
 
+@pytest.mark.SPEOS_UAT
 def test_client_init(speos: Speos):
     """Test the instantiation of a client from the default constructor."""
     assert speos._client.healthy is True
 
 
+@pytest.mark.SPEOS_UAT
 def test_client_through_channel():
     """Test the instantiation of a client from a gRPC channel."""
     target = "dns:///localhost:" + str(config.get("SpeosServerPort"))

--- a/tests/kernel/test_geometry.py
+++ b/tests/kernel/test_geometry.py
@@ -22,6 +22,8 @@
 
 """Test basic geometry database connection."""
 
+import pytest
+
 from ansys.speos.core.kernel.body import BodyLink, ProtoBody
 from ansys.speos.core.kernel.face import FaceLink, ProtoFace
 from ansys.speos.core.kernel.part import ProtoPart
@@ -29,6 +31,7 @@ from ansys.speos.core.speos import Speos
 from tests.kernel.test_scene import create_face_rectangle
 
 
+@pytest.mark.SPEOS_UAT
 def test_create_big_face(speos: Speos):
     """Test create big face."""
     assert speos.client.healthy is True
@@ -64,6 +67,7 @@ def test_create_big_face(speos: Speos):
     face_link.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_create_big_faces(speos: Speos):
     """Test create big faces using batch. Only available from SpeosRPC_Server 25.2."""
     assert speos.client.healthy is True
@@ -123,6 +127,7 @@ def test_create_big_faces(speos: Speos):
         face_link.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_update_big_face(speos: Speos):
     """Test update big face. Bug on SpeosRPC_Server 25.1. Fixed from SpeosRPC_Server 25.2."""
     assert speos.client.healthy is True
@@ -174,6 +179,7 @@ def test_update_big_face(speos: Speos):
     face_link.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_update_big_faces(speos: Speos):
     """Test update big faces using batch. Only available from SpeosRPC_Server 25.2."""
     assert speos.client.healthy is True
@@ -265,6 +271,7 @@ def test_update_big_faces(speos: Speos):
         face_link.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_face(speos: Speos):
     """Test face creation."""
     assert speos.client.healthy is True
@@ -301,6 +308,7 @@ def test_face(speos: Speos):
     rectangle1.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_body(speos: Speos):
     """Test body creation."""
     assert speos.client.healthy is True
@@ -334,6 +342,7 @@ def test_body(speos: Speos):
         face.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_part(speos: Speos):
     """Test part creation."""
     assert speos.client.healthy is True

--- a/tests/kernel/test_geometry.py
+++ b/tests/kernel/test_geometry.py
@@ -67,7 +67,7 @@ def test_create_big_face(speos: Speos):
     face_link.delete()
 
 
-@pytest.mark.SPEOS_UAT
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_create_big_faces(speos: Speos):
     """Test create big faces using batch. Only available from SpeosRPC_Server 25.2."""
     assert speos.client.healthy is True
@@ -127,7 +127,7 @@ def test_create_big_faces(speos: Speos):
         face_link.delete()
 
 
-@pytest.mark.SPEOS_UAT
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_update_big_face(speos: Speos):
     """Test update big face. Bug on SpeosRPC_Server 25.1. Fixed from SpeosRPC_Server 25.2."""
     assert speos.client.healthy is True
@@ -179,7 +179,7 @@ def test_update_big_face(speos: Speos):
     face_link.delete()
 
 
-@pytest.mark.SPEOS_UAT
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_update_big_faces(speos: Speos):
     """Test update big faces using batch. Only available from SpeosRPC_Server 25.2."""
     assert speos.client.healthy is True

--- a/tests/kernel/test_geometry.py
+++ b/tests/kernel/test_geometry.py
@@ -67,7 +67,7 @@ def test_create_big_face(speos: Speos):
     face_link.delete()
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_create_big_faces(speos: Speos):
     """Test create big faces using batch. Only available from SpeosRPC_Server 25.2."""
     assert speos.client.healthy is True
@@ -127,7 +127,7 @@ def test_create_big_faces(speos: Speos):
         face_link.delete()
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_update_big_face(speos: Speos):
     """Test update big face. Bug on SpeosRPC_Server 25.1. Fixed from SpeosRPC_Server 25.2."""
     assert speos.client.healthy is True
@@ -179,7 +179,7 @@ def test_update_big_face(speos: Speos):
     face_link.delete()
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_update_big_faces(speos: Speos):
     """Test update big faces using batch. Only available from SpeosRPC_Server 25.2."""
     assert speos.client.healthy is True

--- a/tests/kernel/test_intensity_template.py
+++ b/tests/kernel/test_intensity_template.py
@@ -24,12 +24,15 @@
 
 from pathlib import Path
 
+import pytest
+
 from ansys.api.speos.common.v1 import data_pb2
 from ansys.speos.core.kernel.intensity_template import ProtoIntensityTemplate
 from ansys.speos.core.speos import Speos
 from tests.conftest import test_path
 
 
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_intensity_template(speos: Speos):
     """Test the intensity template."""
     assert speos.client.healthy is True
@@ -100,6 +103,7 @@ def test_intensity_template(speos: Speos):
         intens_t.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_action_get_library_type_info(speos: Speos):
     """Test the intensity template action : get_library_type_info."""
     assert speos.client.healthy is True

--- a/tests/kernel/test_intensity_template.py
+++ b/tests/kernel/test_intensity_template.py
@@ -32,7 +32,7 @@ from ansys.speos.core.speos import Speos
 from tests.conftest import test_path
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_intensity_template(speos: Speos):
     """Test the intensity template."""
     assert speos.client.healthy is True

--- a/tests/kernel/test_job.py
+++ b/tests/kernel/test_job.py
@@ -123,7 +123,7 @@ def test_job_actions(speos: Speos):
     clean_all_dbs(speos.client)
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.supported_speos_versions(min=251)
 def test_job_actions_interactive_simu(speos: Speos):
     """Test the job actions with interactive simulation."""
     assert speos.client.healthy is True

--- a/tests/kernel/test_job.py
+++ b/tests/kernel/test_job.py
@@ -24,6 +24,8 @@
 
 import time
 
+import pytest
+
 from ansys.speos.core import LOG  # Global logger
 from ansys.speos.core.kernel.job import ProtoJob, messages as job_messages
 from ansys.speos.core.kernel.proto_message_utils import protobuf_message_to_str
@@ -32,6 +34,7 @@ from tests.helper import clean_all_dbs, run_job_and_check_state
 from tests.kernel.test_scene import create_basic_scene
 
 
+@pytest.mark.SPEOS_UAT
 def test_job(speos: Speos):
     """Test the job creation."""
     assert speos.client.healthy is True
@@ -78,6 +81,7 @@ def test_job(speos: Speos):
     clean_all_dbs(speos.client)
 
 
+@pytest.mark.SPEOS_UAT
 def test_job_actions(speos: Speos):
     """Test the job actions."""
     assert speos.client.healthy is True
@@ -119,6 +123,7 @@ def test_job_actions(speos: Speos):
     clean_all_dbs(speos.client)
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_job_actions_interactive_simu(speos: Speos):
     """Test the job actions with interactive simulation."""
     assert speos.client.healthy is True

--- a/tests/kernel/test_logging.py
+++ b/tests/kernel/test_logging.py
@@ -46,6 +46,7 @@ LOG_LEVELS = {
 }
 
 
+@pytest.mark.SPEOS_UAT
 def test_stdout_reading(capfd: pytest.CaptureFixture):
     """Test for checking simple standard output reading by pytest.
 
@@ -60,6 +61,7 @@ def test_stdout_reading(capfd: pytest.CaptureFixture):
     assert out == "This is a test\n"
 
 
+@pytest.mark.SPEOS_UAT
 def test_only_logger(caplog: pytest.LogCaptureFixture):
     """Test for checking that the logging capabilities are working fine.
 
@@ -75,12 +77,14 @@ def test_only_logger(caplog: pytest.LogCaptureFixture):
     assert "This is another test" in caplog.text
 
 
+@pytest.mark.SPEOS_UAT
 def test_global_logger_exist():
     """Test for checking the accurate naming of the general Logger instance."""
     assert isinstance(LOG.logger, deflogging.Logger)
     assert LOG.logger.name == "pyspeos_global"
 
 
+@pytest.mark.SPEOS_UAT
 def test_global_logger_has_handlers():
     """Test for checking that the general Logger has file_handlers \
 
@@ -92,6 +96,7 @@ def test_global_logger_has_handlers():
     assert LOG.file_handler or LOG.std_out_handler  # at least a handler is not empty
 
 
+@pytest.mark.SPEOS_UAT
 def test_global_logger_logging(caplog: pytest.LogCaptureFixture):
     """Testing the global PySpeos logger capabilities.
 
@@ -120,6 +125,7 @@ def test_global_logger_logging(caplog: pytest.LogCaptureFixture):
     LOG.std_out_handler.setLevel("ERROR")
 
 
+@pytest.mark.SPEOS_UAT
 def test_global_logger_level_mode():
     """Checking that the Logger levels are stored as integer values \
 
@@ -129,6 +135,7 @@ def test_global_logger_level_mode():
     assert LOG.logger.level == logger.ERROR
 
 
+@pytest.mark.SPEOS_UAT
 def test_global_logger_exception_handling(caplog: pytest.LogCaptureFixture):
     """Test for checking that Errors are also raised in the logger as ERROR type.
 
@@ -160,6 +167,7 @@ def test_global_logger_exception_handling(caplog: pytest.LogCaptureFixture):
         deflogging.CRITICAL,
     ],
 )
+@pytest.mark.SPEOS_UAT
 def test_global_logger_debug_levels(level: int, caplog: pytest.LogCaptureFixture):
     """Testing for all the possible logging level that the output is recorded properly.
 
@@ -191,6 +199,7 @@ def test_global_logger_debug_levels(level: int, caplog: pytest.LogCaptureFixture
                 )
 
 
+@pytest.mark.SPEOS_UAT
 def test_global_logger_format(fake_record: Callable):
     """Test for checking the global logger formatter aspect.
 
@@ -220,6 +229,7 @@ def test_global_logger_format(fake_record: Callable):
     assert "This is a message" in logging
 
 
+@pytest.mark.SPEOS_UAT
 def test_global_methods(caplog: pytest.LogCaptureFixture):
     """Testing global logger methods for printing out different log messages.
 
@@ -260,6 +270,7 @@ def test_global_methods(caplog: pytest.LogCaptureFixture):
     LOG.std_out_handler.setLevel("INFO")
 
 
+@pytest.mark.SPEOS_UAT
 def test_log_to_file(tmp_path_factory: pytest.TempPathFactory):
     """
     Testing writing to log file.

--- a/tests/kernel/test_scene.py
+++ b/tests/kernel/test_scene.py
@@ -646,7 +646,7 @@ def test_scene_actions_load_modify(speos: Speos):
     clean_all_dbs(speos.client)
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_scene_actions_get_source_ray_paths(speos: Speos):
     """Test the scene action: load file and modify sensors."""
     assert speos.client.healthy is True

--- a/tests/kernel/test_scene.py
+++ b/tests/kernel/test_scene.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import List, Mapping, Optional
 
 import numpy as np
+import pytest
 
 from ansys.api.speos.sensor.v1 import common_pb2, irradiance_sensor_pb2
 from ansys.api.speos.simulation.v1 import simulation_template_pb2
@@ -45,6 +46,7 @@ from tests.conftest import test_path
 from tests.helper import clean_all_dbs
 
 
+@pytest.mark.SPEOS_UAT
 def create_basic_scene(speos: Speos) -> SceneLink:
     """Create basic scene."""
     assert speos.client.healthy is True
@@ -369,6 +371,7 @@ def create_basic_scene(speos: Speos) -> SceneLink:
     return scene
 
 
+@pytest.mark.SPEOS_UAT
 def create_face_rectangle(
     name: str,
     description: str = "",
@@ -433,6 +436,7 @@ def create_face_rectangle(
     return face
 
 
+@pytest.mark.SPEOS_UAT
 def create_body_box(
     name: str,
     face_stub: FaceStub,
@@ -566,6 +570,7 @@ def create_body_box(
     return body
 
 
+@pytest.mark.SPEOS_UAT
 def test_scene(speos: Speos):
     """Test the scene creation."""
     assert speos.client.healthy is True
@@ -576,6 +581,7 @@ def test_scene(speos: Speos):
     clean_all_dbs(speos.client)
 
 
+@pytest.mark.SPEOS_UAT
 def test_scene_actions_load(speos: Speos):
     """Test the scene action: load file."""
     assert speos.client.healthy is True
@@ -595,6 +601,7 @@ def test_scene_actions_load(speos: Speos):
     clean_all_dbs(speos.client)
 
 
+@pytest.mark.SPEOS_UAT
 def test_scene_actions_load_modify(speos: Speos):
     """Test the scene action: load file and modify sensors."""
     assert speos.client.healthy is True
@@ -639,6 +646,7 @@ def test_scene_actions_load_modify(speos: Speos):
     clean_all_dbs(speos.client)
 
 
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_scene_actions_get_source_ray_paths(speos: Speos):
     """Test the scene action: load file and modify sensors."""
     assert speos.client.healthy is True

--- a/tests/kernel/test_sensor_template.py
+++ b/tests/kernel/test_sensor_template.py
@@ -24,6 +24,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from ansys.api.speos.sensor.v1 import (
     camera_sensor_pb2,
     common_pb2,
@@ -34,6 +36,7 @@ from ansys.speos.core.speos import Speos
 from tests.conftest import test_path
 
 
+@pytest.mark.SPEOS_UAT
 def test_sensor_template(speos: Speos):
     """Test the sensor template."""
     assert speos.client.healthy is True

--- a/tests/kernel/test_simulation_template.py
+++ b/tests/kernel/test_simulation_template.py
@@ -22,11 +22,14 @@
 
 """Test basic sop template database connection."""
 
+import pytest
+
 from ansys.api.speos.simulation.v1 import simulation_template_pb2
 from ansys.speos.core.kernel.simulation_template import ProtoSimulationTemplate
 from ansys.speos.core.speos import Speos
 
 
+@pytest.mark.SPEOS_UAT
 def test_simulation_template(speos: Speos):
     """Test the simulation template."""
     assert speos.client.healthy is True

--- a/tests/kernel/test_sop_template.py
+++ b/tests/kernel/test_sop_template.py
@@ -33,6 +33,7 @@ from ansys.speos.core.speos import Speos
 from tests.conftest import test_path
 
 
+@pytest.mark.SPEOS_UAT
 def test_sop_template(speos: Speos):
     """Test the sop template creation."""
     assert speos.client.healthy is True

--- a/tests/kernel/test_source_template.py
+++ b/tests/kernel/test_source_template.py
@@ -36,6 +36,7 @@ from ansys.speos.core.speos import Speos
 from tests.conftest import test_path
 
 
+@pytest.mark.SPEOS_UAT
 def test_source_template(speos: Speos):
     """Test the source template creation."""
     assert speos.client.healthy is True
@@ -139,6 +140,7 @@ def test_source_template(speos: Speos):
     intens_t_lamb.delete()
 
 
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_action_get_ray_file_info(speos: Speos):
     """Test the source template action : get_ray_file_info."""
     assert speos.client.healthy is True

--- a/tests/kernel/test_source_template.py
+++ b/tests/kernel/test_source_template.py
@@ -140,7 +140,7 @@ def test_source_template(speos: Speos):
     intens_t_lamb.delete()
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_action_get_ray_file_info(speos: Speos):
     """Test the source template action : get_ray_file_info."""
     assert speos.client.healthy is True

--- a/tests/kernel/test_spectrum.py
+++ b/tests/kernel/test_spectrum.py
@@ -24,11 +24,14 @@
 
 from pathlib import Path
 
+import pytest
+
 from ansys.speos.core.kernel.spectrum import ProtoSpectrum
 from ansys.speos.core.speos import Speos
 from tests.conftest import test_path
 
 
+@pytest.mark.SPEOS_UAT
 def test_client_spectrum_init(speos: Speos):
     """Test the abstraction layer for spectrums. How to use SpectrumLink objects."""
     assert speos.client.healthy is True
@@ -84,6 +87,7 @@ def test_client_spectrum_init(speos: Speos):
         spec.delete()
 
 
+@pytest.mark.SPEOS_UAT
 def test_spectrum(speos: Speos):
     """Test spectrum."""
     assert speos.client.healthy is True

--- a/tests/kernel/test_vop_template.py
+++ b/tests/kernel/test_vop_template.py
@@ -33,6 +33,7 @@ from ansys.speos.core.speos import Speos
 from tests.conftest import test_path
 
 
+@pytest.mark.SPEOS_UAT
 def test_vop_template(speos: Speos):
     """Test the vop template creation."""
     assert speos.client.healthy is True

--- a/tests/stubs/test_anisotropic_bsdf.py
+++ b/tests/stubs/test_anisotropic_bsdf.py
@@ -26,6 +26,7 @@ import math
 from pathlib import Path
 
 from google.protobuf.empty_pb2 import Empty
+import pytest
 
 import ansys.api.speos.bsdf.v1.anisotropic_bsdf_pb2 as anisotropic_bsdf__v1__pb2
 import ansys.api.speos.bsdf.v1.anisotropic_bsdf_pb2_grpc as anisotropic_bsdf__v1__pb2_grpc
@@ -34,6 +35,7 @@ from tests.conftest import test_path
 import tests.helper as helper
 
 
+@pytest.mark.SPEOS_UAT
 def create_anisotropic_bsdf():
     """Create a lambertian bsdf."""
     bsdf = anisotropic_bsdf__v1__pb2.AnisotropicBsdfData()
@@ -110,11 +112,13 @@ def create_anisotropic_bsdf():
     return bsdf
 
 
+@pytest.mark.SPEOS_UAT
 def approx_cmp(a, b):
     """Approximated comparison of two numbers."""
     return math.fabs(a - b) < 1e-6
 
 
+@pytest.mark.SPEOS_UAT
 def compare_anisotropic_bsdf(bsdf1, bsdf2):
     """Compare 2 bsdf."""
     # description
@@ -264,6 +268,7 @@ def compare_anisotropic_bsdf(bsdf1, bsdf2):
     return True
 
 
+@pytest.mark.SPEOS_UAT
 def compare_enhancement_data(cones1, cones2):
     """Compare enhancement cones."""
     if len(cones1.anisotropic_samples) != len(cones2.anisotropic_samples):
@@ -281,6 +286,7 @@ def compare_enhancement_data(cones1, cones2):
     return True
 
 
+@pytest.mark.SPEOS_UAT
 def compare_specular_enhancement_data(data1, data2):
     """Compare specular enhancement information."""
     if (
@@ -294,6 +300,7 @@ def compare_specular_enhancement_data(data1, data2):
     ) and compare_enhancement_data(data1.transmission, data2.transmission)
 
 
+@pytest.mark.SPEOS_UAT
 def test_grpc_anisotropic_bsdf(speos: Speos):
     """Test for anisotropic bsdf service."""
     stub = anisotropic_bsdf__v1__pb2_grpc.AnisotropicBsdfServiceStub(speos.client.channel)

--- a/tests/stubs/test_bsdf_creation.py
+++ b/tests/stubs/test_bsdf_creation.py
@@ -25,6 +25,8 @@
 import math
 from pathlib import Path
 
+import pytest
+
 import ansys.api.speos.bsdf.v1.bsdf_creation_pb2 as bsdf_creation__v1__pb2
 import ansys.api.speos.bsdf.v1.bsdf_creation_pb2_grpc as bsdf_creation__v1__pb2_grpc
 from ansys.speos.core.speos import Speos
@@ -32,6 +34,7 @@ from tests.conftest import test_path
 import tests.helper as helper
 
 
+@pytest.mark.SPEOS_UAT
 def test_grpc_spectral_bsdf(speos: Speos):
     """Test for spectral bsdf service (*.BRDF)."""
     stub = bsdf_creation__v1__pb2_grpc.BsdfCreationServiceStub(speos.client.channel)

--- a/tests/stubs/test_eulumdat_file.py
+++ b/tests/stubs/test_eulumdat_file.py
@@ -25,6 +25,8 @@
 import logging
 from pathlib import Path
 
+import pytest
+
 from ansys.api.speos.intensity_distributions.v1 import (
     eulumdat_pb2,
     eulumdat_pb2_grpc,
@@ -34,6 +36,7 @@ from tests.conftest import test_path
 import tests.helper as helper
 
 
+@pytest.mark.SPEOS_UAT
 def create_eulumdat_intensity():
     """Create simple eulumdat file."""
     eulumdat = eulumdat_pb2.EulumdatIntensityDistribution()
@@ -105,6 +108,7 @@ def create_eulumdat_intensity():
     return eulumdat
 
 
+@pytest.mark.SPEOS_UAT
 def compare_eulumdat_intensities(eulumdat1, eulumdat2):
     """Compare 2 eulumdat files."""
     # file information
@@ -222,6 +226,7 @@ def compare_eulumdat_intensities(eulumdat1, eulumdat2):
     return True
 
 
+@pytest.mark.SPEOS_UAT
 def test_grpc_eulumdat_intensity(speos: Speos):
     """Test for eulumdat intensity service."""
     stub = eulumdat_pb2_grpc.EulumdatIntensityServiceStub(speos.client.channel)

--- a/tests/stubs/test_file_transfer.py
+++ b/tests/stubs/test_file_transfer.py
@@ -24,6 +24,8 @@
 
 from pathlib import Path
 
+import pytest
+
 import ansys.api.speos.file.v1.file_transfer as file_transfer_helper__v1
 import ansys.api.speos.file.v1.file_transfer_pb2 as file_transfer__v1__pb2
 import ansys.api.speos.file.v1.file_transfer_pb2_grpc as file_transfer__v1__pb2_grpc
@@ -31,6 +33,7 @@ from ansys.speos.core.speos import Speos
 from tests.conftest import local_test_path
 
 
+@pytest.mark.SPEOS_UAT
 def test_transfer_file(speos: Speos):
     """Test to check file transfer."""
     file_transfer_stub = file_transfer__v1__pb2_grpc.FileTransferServiceStub(speos.client.channel)
@@ -106,6 +109,7 @@ def _check_downloaded_files(download_responses, expected_file_names, download_lo
     assert len(expected_file_names) == 0
 
 
+@pytest.mark.SPEOS_UAT
 def test_transfer_folder(speos: Speos):
     """Test to check folder transfer."""
     file_transfer_stub = file_transfer__v1__pb2_grpc.FileTransferServiceStub(speos.client.channel)

--- a/tests/stubs/test_ies_file.py
+++ b/tests/stubs/test_ies_file.py
@@ -25,6 +25,8 @@
 import logging
 from pathlib import Path
 
+import pytest
+
 from ansys.api.speos.intensity_distributions.v1 import ies_pb2, ies_pb2_grpc
 from ansys.speos.core.speos import Speos
 from tests.conftest import test_path
@@ -136,6 +138,7 @@ def compare_ies_intensities(ies1, ies2):
     return True
 
 
+@pytest.mark.SPEOS_UAT
 def test_grpc_ies_intensity(speos: Speos):
     """Test to check ies intensity service."""
     stub = ies_pb2_grpc.IesIntensityServiceStub(speos.client.channel)

--- a/tests/stubs/test_lpf_file_reader.py
+++ b/tests/stubs/test_lpf_file_reader.py
@@ -35,7 +35,7 @@ from ansys.speos.core.speos import Speos
 from tests.conftest import local_test_path, test_path
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.supported_speos_versions(min=251)
 def test_lpf_file_reader_mono_v2_direct_simu(speos: Speos):
     """Test to check lpf reader for direct simulation."""
     # Lpf file reader creation
@@ -93,7 +93,7 @@ def test_lpf_file_reader_mono_v2_direct_simu(speos: Speos):
     stub.CloseLpfFileName(lpf_file_reader__v2__pb2.CloseLpfFileName_Request_Mono())
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.supported_speos_versions(min=251)
 def test_lpf_file_reader_mono_v2_inverse_simu(speos: Speos):
     """Test to check lpf service for inverse simulation."""
     # Lpf file reader creation
@@ -132,7 +132,7 @@ def test_lpf_file_reader_mono_v2_inverse_simu(speos: Speos):
     stub.CloseLpfFileName(lpf_file_reader__v2__pb2.CloseLpfFileName_Request_Mono())
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.supported_speos_versions(min=251)
 def test_lpf_file_reader_multi_v2(speos: Speos):
     """Test to check multifile lpf service."""
     # Lpf file reader multi creation
@@ -217,7 +217,7 @@ def test_lpf_file_reader_multi_v2(speos: Speos):
     stub.Delete(lpf_file_reader__v2__pb2.Delete_Request_Multi(lpf_reader_guid=guid))
 
 
-@pytest.mark.SPEOS_25_1_0_MIN
+@pytest.mark.supported_speos_versions(min=251)
 def test_lpf_file_reader_mono_v2_direct_simu_with_file_transfer(speos: Speos):
     """Test to check lpf service with file transfer service."""
     # local file upload to the server

--- a/tests/stubs/test_lpf_file_reader.py
+++ b/tests/stubs/test_lpf_file_reader.py
@@ -24,6 +24,8 @@
 
 from pathlib import Path
 
+import pytest
+
 import ansys.api.speos.file.v1.file_transfer as file_transfer_helper__v1
 import ansys.api.speos.file.v1.file_transfer_pb2 as file_transfer__v1__pb2
 import ansys.api.speos.file.v1.file_transfer_pb2_grpc as file_transfer__v1__pb2_grpc
@@ -33,6 +35,7 @@ from ansys.speos.core.speos import Speos
 from tests.conftest import local_test_path, test_path
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_lpf_file_reader_mono_v2_direct_simu(speos: Speos):
     """Test to check lpf reader for direct simulation."""
     # Lpf file reader creation
@@ -90,6 +93,7 @@ def test_lpf_file_reader_mono_v2_direct_simu(speos: Speos):
     stub.CloseLpfFileName(lpf_file_reader__v2__pb2.CloseLpfFileName_Request_Mono())
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_lpf_file_reader_mono_v2_inverse_simu(speos: Speos):
     """Test to check lpf service for inverse simulation."""
     # Lpf file reader creation
@@ -104,7 +108,8 @@ def test_lpf_file_reader_mono_v2_inverse_simu(speos: Speos):
     nb_of_traces = res_information.nb_of_traces
     assert nb_of_traces == 21044
     assert res_information.nb_of_xmps == 1
-    assert res_information.has_sensor_contributions is True  # contributions stored in Inverse simu
+    # contributions stored in Inverse simu
+    assert res_information.has_sensor_contributions is True
     assert len(res_information.sensor_names) == 1
     assert res_information.sensor_names[0] == "Camera_Perfect_Lens_System_V2:3"
 
@@ -127,6 +132,7 @@ def test_lpf_file_reader_mono_v2_inverse_simu(speos: Speos):
     stub.CloseLpfFileName(lpf_file_reader__v2__pb2.CloseLpfFileName_Request_Mono())
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_lpf_file_reader_multi_v2(speos: Speos):
     """Test to check multifile lpf service."""
     # Lpf file reader multi creation
@@ -211,6 +217,7 @@ def test_lpf_file_reader_multi_v2(speos: Speos):
     stub.Delete(lpf_file_reader__v2__pb2.Delete_Request_Multi(lpf_reader_guid=guid))
 
 
+@pytest.mark.SPEOS_25_1_0_MIN
 def test_lpf_file_reader_mono_v2_direct_simu_with_file_transfer(speos: Speos):
     """Test to check lpf service with file transfer service."""
     # local file upload to the server

--- a/tests/stubs/test_spectral_bsdf.py
+++ b/tests/stubs/test_spectral_bsdf.py
@@ -26,6 +26,7 @@ import math
 from pathlib import Path
 
 from google.protobuf.empty_pb2 import Empty
+import pytest
 
 import ansys.api.speos.bsdf.v1.spectral_bsdf_pb2 as spectral_bsdf__v1__pb2
 import ansys.api.speos.bsdf.v1.spectral_bsdf_pb2_grpc as spectral_bsdf__v1__pb2_grpc
@@ -148,6 +149,7 @@ def compare_specular_enhancement_data(c1, c2):
     return True
 
 
+@pytest.mark.SPEOS_UAT
 def test_grpc_spectral_bsdf(speos: Speos):
     """Test to check Spectral bsdf service."""
     stub = spectral_bsdf__v1__pb2_grpc.SpectralBsdfServiceStub(speos.client.channel)

--- a/tests/stubs/test_xmp_intensity_file.py
+++ b/tests/stubs/test_xmp_intensity_file.py
@@ -25,6 +25,8 @@
 import logging
 from pathlib import Path
 
+import pytest
+
 from ansys.api.speos.intensity_distributions.v1 import (
     base_map_template_pb2,
     extended_map_template_pb2,
@@ -150,6 +152,7 @@ def compare_xmp_intensity_distributions(xmp1, xmp2):
     return True
 
 
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_grpc_xmp_intensity(speos: Speos):
     """Test to check intensity xmp service."""
     stub = xmp_pb2_grpc.XmpIntensityServiceStub(speos.client.channel)

--- a/tests/stubs/test_xmp_intensity_file.py
+++ b/tests/stubs/test_xmp_intensity_file.py
@@ -152,7 +152,7 @@ def compare_xmp_intensity_distributions(xmp1, xmp2):
     return True
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_grpc_xmp_intensity(speos: Speos):
     """Test to check intensity xmp service."""
     stub = xmp_pb2_grpc.XmpIntensityServiceStub(speos.client.channel)

--- a/tests/stubs/test_xmp_spectral_intensity_file.py
+++ b/tests/stubs/test_xmp_spectral_intensity_file.py
@@ -25,6 +25,8 @@
 import logging
 from pathlib import Path
 
+import pytest
+
 from ansys.api.speos.intensity_distributions.v1 import (
     base_map_template_pb2,
     spectral_map_template_pb2,
@@ -224,6 +226,7 @@ def compare_xmp_intensity_distributions(xmp1, xmp2):
     return True
 
 
+@pytest.mark.SPEOS_UAT
 def test_grpc_xmp_intensity(speos: Speos):
     """Test to check spectral intensity xmp service."""
     stub = xmp_pb2_grpc.XmpIntensityServiceStub(speos.client.channel)

--- a/tests/workflow/test_combine_speos.py
+++ b/tests/workflow/test_combine_speos.py
@@ -189,7 +189,7 @@ def test_modify_parts_after_combine(speos: Speos):
             ]
 
 
-@pytest.mark.SPEOS_UAT
+@pytest.mark.SPEOS_25_2_0_MIN
 def test_insert_speos(speos: Speos):
     """Test inserting several speos files in an existing project."""
     # Create a project from a speos file

--- a/tests/workflow/test_combine_speos.py
+++ b/tests/workflow/test_combine_speos.py
@@ -189,7 +189,7 @@ def test_modify_parts_after_combine(speos: Speos):
             ]
 
 
-@pytest.mark.SPEOS_25_2_0_MIN
+@pytest.mark.supported_speos_versions(min=252)
 def test_insert_speos(speos: Speos):
     """Test inserting several speos files in an existing project."""
     # Create a project from a speos file

--- a/tests/workflow/test_combine_speos.py
+++ b/tests/workflow/test_combine_speos.py
@@ -24,6 +24,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from ansys.speos.core import OptProp, Part, Project, Speos
 from ansys.speos.core.sensor import SensorIrradiance
 from ansys.speos.core.workflow.combine_speos import (
@@ -34,6 +36,7 @@ from ansys.speos.core.workflow.combine_speos import (
 from tests.conftest import test_path
 
 
+@pytest.mark.SPEOS_UAT
 def test_combine_speos(speos: Speos):
     """Test combining several speos files."""
     # Combine several speos files into a new project - only geometries + materials are retrieved
@@ -113,6 +116,7 @@ def test_combine_speos(speos: Speos):
     assert len(ssr) == 0
 
 
+@pytest.mark.SPEOS_UAT
 def test_modify_parts_after_combine(speos: Speos):
     """Test combining several speos files, and modify parts after that."""
     # Combine several speos files into a new project - only geometries + materials are retrieved
@@ -185,6 +189,7 @@ def test_modify_parts_after_combine(speos: Speos):
             ]
 
 
+@pytest.mark.SPEOS_UAT
 def test_insert_speos(speos: Speos):
     """Test inserting several speos files in an existing project."""
     # Create a project from a speos file


### PR DESCRIPTION
## Description
Updated Nightly workflow unittest to run in the following Speos RPC releases: 251, 252, and latest; with only the respective supported features.

The pytest functions are filtered based on were marked with 

## Issue linked
Close [#733](https://github.com/ansys/pyspeos/issues/733)

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
