### PR TITLE
test: refactor natural light source data checks

### DIFF
--- a/doc/changelog.d/920.test.md
+++ b/doc/changelog.d/920.test.md
@@ -1,0 +1,1 @@
+Refactor natural light source data checks

--- a/src/ansys/speos/core/generic/parameters.py
+++ b/src/ansys/speos/core/generic/parameters.py
@@ -692,17 +692,32 @@ class SurfaceSourceParameters:
 
 @dataclass
 class AutomaticSunParameters:
-    """Spectrum Exit Parameters."""
+    """Automatic Sun Parameters."""
 
-    now = datetime.datetime.now()
     time_zone: str = "CET"
     longitude: float = 0.0
     latitude: float = 0.0
-    year = now.year
-    month = now.month
-    day = now.day
-    hour = now.hour
-    minute = now.minute
+    year: int = field(default=-1)
+    month: int = field(default=-1)
+    day: int = field(default=-1)
+    hour: int = field(default=-1)
+    minute: int = field(default=-1)
+
+    def __post_init__(self) -> None:
+        """Initialize year, month, day, hour, minute from time_zone if not set."""
+        from zoneinfo import ZoneInfo
+
+        now = datetime.datetime.now(ZoneInfo(self.time_zone))
+        if self.year == -1:
+            self.year = now.year
+        if self.month == -1:
+            self.month = now.month
+        if self.day == -1:
+            self.day = now.day
+        if self.hour == -1:
+            self.hour = now.hour
+        if self.minute == -1:
+            self.minute = now.minute
 
 
 @dataclass

--- a/tests/core/test_source.py
+++ b/tests/core/test_source.py
@@ -811,6 +811,9 @@ def test_create_natural_light_source(speos: Speos):
         default_parameters=AmbientNaturalLightParameters(),
     )
     after = datetime.datetime.now(cet)
+    tmp_natural_light_property = (
+        source1._source_instance.ambient_properties.natural_light_properties
+    )
     auto_sun = tmp_natural_light_property.sun_axis_system.automatic_sun
 
     assert source1._source_instance.HasField("ambient_properties")
@@ -820,9 +823,6 @@ def test_create_natural_light_source(speos: Speos):
         1,
     ]
     assert source1._source_instance.ambient_properties.HasField("natural_light_properties")
-    tmp_natural_light_property = (
-        source1._source_instance.ambient_properties.natural_light_properties
-    )
     assert tmp_natural_light_property.north_direction == [
         0,
         1,
@@ -841,8 +841,10 @@ def test_create_natural_light_source(speos: Speos):
         minute=auto_sun.minute,
         tzinfo=cet,
     )
-    assert before - datetime.timedelta(seconds=60) <= server_dt <= after + datetime.timedelta(
-        seconds=60
+    assert (
+        before - datetime.timedelta(seconds=60)
+        <= server_dt
+        <= after + datetime.timedelta(seconds=60)
     )
     assert auto_sun.time_zone_uri == "CET"
 

--- a/tests/core/test_source.py
+++ b/tests/core/test_source.py
@@ -841,8 +841,10 @@ def test_create_natural_light_source(speos: Speos):
         minute=auto_sun.minute,
         tzinfo=cet,
     )
-    assert before - datetime.timedelta(seconds=60) <= server_dt <= after + datetime.timedelta(
-        seconds=60
+    assert (
+        before - datetime.timedelta(seconds=60)
+        <= server_dt
+        <= after + datetime.timedelta(seconds=60)
     )
     assert auto_sun.time_zone_uri == "CET"
 

--- a/tests/core/test_source.py
+++ b/tests/core/test_source.py
@@ -800,15 +800,19 @@ def test_create_rayfile_source(speos: Speos):
 @pytest.mark.supported_speos_versions(min=252)
 def test_create_natural_light_source(speos: Speos):
     """Test creation of ambient natural light source."""
-    p = Project(speos=speos)
+    from zoneinfo import ZoneInfo
 
-    # Default value :
+    p = Project(speos=speos)
+    cet = ZoneInfo("CET")
+    before = datetime.datetime.now(cet)
     source1 = SourceAmbientNaturalLight(
         p,
         name="NaturalLight.1",
         default_parameters=AmbientNaturalLightParameters(),
     )
-    now = datetime.datetime.now()
+    after = datetime.datetime.now(cet)
+    auto_sun = tmp_natural_light_property.sun_axis_system.automatic_sun
+
     assert source1._source_instance.HasField("ambient_properties")
     assert source1._source_instance.ambient_properties.zenith_direction == [
         0,
@@ -826,12 +830,21 @@ def test_create_natural_light_source(speos: Speos):
     ]
     assert tmp_natural_light_property.HasField("sun_axis_system")
     assert tmp_natural_light_property.sun_axis_system.HasField("automatic_sun")
-    assert tmp_natural_light_property.sun_axis_system.automatic_sun.year == now.year
-    assert tmp_natural_light_property.sun_axis_system.automatic_sun.month == now.month
-    assert tmp_natural_light_property.sun_axis_system.automatic_sun.day == now.day
-    assert tmp_natural_light_property.sun_axis_system.automatic_sun.hour == now.hour
-    assert abs(tmp_natural_light_property.sun_axis_system.automatic_sun.minute - now.minute) < 10
-    assert tmp_natural_light_property.sun_axis_system.automatic_sun.time_zone_uri == "CET"
+    # NOTE: Reconstruct the server datetime in CET and verify it falls within the [before, after]
+    # window. This avoids flaky failures when the test runs near a minute/hour boundary.
+    # This happened in the nightly run which starts at 03:00 UTC.
+    server_dt = datetime.datetime(
+        year=auto_sun.year,
+        month=auto_sun.month,
+        day=auto_sun.day,
+        hour=auto_sun.hour,
+        minute=auto_sun.minute,
+        tzinfo=cet,
+    )
+    assert before - datetime.timedelta(seconds=60) <= server_dt <= after + datetime.timedelta(
+        seconds=60
+    )
+    assert auto_sun.time_zone_uri == "CET"
 
     assert source1._source_template.HasField("ambient")
     assert source1._source_template.ambient.HasField("natural_light")

--- a/tests/core/test_source.py
+++ b/tests/core/test_source.py
@@ -814,7 +814,6 @@ def test_create_natural_light_source(speos: Speos):
     tmp_natural_light_property = (
         source1._source_instance.ambient_properties.natural_light_properties
     )
-    auto_sun = tmp_natural_light_property.sun_axis_system.automatic_sun
 
     assert source1._source_instance.HasField("ambient_properties")
     assert source1._source_instance.ambient_properties.zenith_direction == [
@@ -833,6 +832,7 @@ def test_create_natural_light_source(speos: Speos):
     # NOTE: Reconstruct the server datetime in CET and verify it falls within the [before, after]
     # window. This avoids flaky failures when the test runs near a minute/hour boundary.
     # This happened in the nightly run which starts at 03:00 UTC.
+    auto_sun = tmp_natural_light_property.sun_axis_system.automatic_sun
     server_dt = datetime.datetime(
         year=auto_sun.year,
         month=auto_sun.month,
@@ -936,8 +936,9 @@ def test_create_natural_light_source(speos: Speos):
 
     source1.delete()
 
+    before2 = datetime.datetime.now(cet)
     source2 = p.create_source(name="NaturalLight.2", feature_type=SourceAmbientNaturalLight)
-    now = datetime.datetime.now()
+    after2 = datetime.datetime.now(cet)
     assert source2._source_instance.HasField("ambient_properties")
     assert source2._source_instance.ambient_properties.zenith_direction == [
         0,
@@ -955,12 +956,24 @@ def test_create_natural_light_source(speos: Speos):
     ]
     assert tmp_natural_light_property.HasField("sun_axis_system")
     assert tmp_natural_light_property.sun_axis_system.HasField("automatic_sun")
-    assert tmp_natural_light_property.sun_axis_system.automatic_sun.year == now.year
-    assert tmp_natural_light_property.sun_axis_system.automatic_sun.month == now.month
-    assert tmp_natural_light_property.sun_axis_system.automatic_sun.day == now.day
-    assert tmp_natural_light_property.sun_axis_system.automatic_sun.hour == now.hour
-    assert abs(tmp_natural_light_property.sun_axis_system.automatic_sun.minute - now.minute) < 10
-    assert tmp_natural_light_property.sun_axis_system.automatic_sun.time_zone_uri == "CET"
+    # NOTE: Reconstruct the server datetime in CET and verify it falls within the [before, after]
+    # window. This avoids flaky failures when the test runs near a minute/hour boundary.
+    # This happened in the nightly run which starts at 03:00 UTC.
+    auto_sun2 = tmp_natural_light_property.sun_axis_system.automatic_sun
+    server_dt2 = datetime.datetime(
+        year=auto_sun2.year,
+        month=auto_sun2.month,
+        day=auto_sun2.day,
+        hour=auto_sun2.hour,
+        minute=auto_sun2.minute,
+        tzinfo=cet,
+    )
+    assert (
+        before2 - datetime.timedelta(seconds=60)
+        <= server_dt2
+        <= after2 + datetime.timedelta(seconds=60)
+    )
+    assert auto_sun2.time_zone_uri == "CET"
 
     assert source2._source_template.HasField("ambient")
     assert source2._source_template.ambient.HasField("natural_light")


### PR DESCRIPTION
## Description
This pull request refactors how natural light source data and time zone handling are managed, both in the core parameters and in the associated tests. The main focus is on improving reliability and accuracy when initializing and verifying date/time values for natural light sources, especially regarding time zones, to avoid flaky test failures.

This should avoid the random failure faced in the nightly runs, see below
<img width="1422" height="639" alt="image" src="https://github.com/user-attachments/assets/eaa0ff2e-64fa-4705-8efb-5453d7eef897" />

Each of those was failing due to a comparison in expected hours.

## Issue linked
Close #916 

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
