### PR TITLE
test: do not use unneeded typing.override

### DIFF
--- a/doc/changelog.d/946.test.md
+++ b/doc/changelog.d/946.test.md
@@ -1,0 +1,1 @@
+Do not use unneeded typing.override

--- a/tests/core/test_simulation.py
+++ b/tests/core/test_simulation.py
@@ -29,7 +29,6 @@ import re
 from threading import Thread
 from time import sleep
 from types import SimpleNamespace
-import typing
 
 from ansys.api.speos.simulation.v1 import simulation_template_pb2
 import pytest
@@ -1191,8 +1190,7 @@ def test_export_old_version(monkeypatch, tmp_path):
     saved_requests = []
 
     class FakeActionsStub:
-        @typing.override
-        def SaveFile(self, request):
+        def SaveFile(self, request):  # noqa: N802
             saved_requests.append(request)
 
     project = SimpleNamespace(


### PR DESCRIPTION
## Description
In #926 a change that is not compatible with python 3.10 and 3.11 was added resulting in nightly test failures.
This PR solves this issue by removing the unneeded `typing.override` usage (not relevant here since the class doesn't inherit from another class) and simply disabling the failing ruff check on the test line.

## Issue linked
Close #945

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
