### PR TITLE
docs: refactor download button

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -10,6 +10,10 @@
   description: Improvements or additions to documentation
   color: 0677ba
 
+- name: deploy-pr-doc
+  description: Deploy pull request documentation
+  color: 00ff00
+
 - name: enhancement
   description: New features or code improvements
   color: FFD827

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -293,6 +293,23 @@ jobs:
           docker kill speos-rpc
           docker rm speos-rpc
 
+  doc-deploy-pr:
+    name: Deploy PR documentation
+    if: contains(github.event.pull_request.labels.*.name, 'deploy-pr-doc')
+    needs: [doc-build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to update files on the gh-pages branch
+      pull-requests: write # Needed to create deployment comments on PRs
+    steps:
+      - uses: ansys/actions/doc-deploy-pr@d946b24b9a765f4169bcc94afdb27bd1a0533741 # v10.3.2
+        with:
+          bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+          bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
+          cname: ${{ env.DOCUMENTATION_CNAME }}
+          maximum-pr-doc-deployments: 5
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   # NOTE: Should this job be using ansys/actions/tests-pytest ?
   testing:
     name: Testing and coverage

--- a/doc/changelog.d/998.documentation.md
+++ b/doc/changelog.d/998.documentation.md
@@ -1,0 +1,1 @@
+Refactor download button

--- a/doc/source/_static/js/download_notebooks.js
+++ b/doc/source/_static/js/download_notebooks.js
@@ -1,0 +1,5 @@
+document.addEventListener("DOMContentLoaded", function () {
+    document.querySelectorAll('a[href$=".ipynb"]').forEach(function (link) {
+        link.setAttribute("download", "");
+    });
+});

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -109,6 +109,11 @@ numpydoc_validation_checks = {
 # static path
 html_static_path = ["_static"]
 html_css_files = ["custom.css"]
+# Extra JavaScript files to include in the HTML output. They are included to ensure that
+# the download button in the admonition is working correctly.
+html_js_files = [
+    "js/download_notebooks.js",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -149,50 +154,33 @@ if BUILD_EXAMPLES:
         "examples/workflow/combine-speos": "_static/thumbnails/workflow_moving_car.PNG",
     }
     nbsphinx_prompt_width = ""
-    nbsphinx_prolog = """
-
-.. only:: html
-
-    .. grid:: 5
-
-        .. grid-item::
-
-        .. grid-item::
-            :child-align: center
-
-            .. button-link:: {cname_pref}/{python_file_loc}
-                :color: primary
-                :shadow:
-
-                Download as Python script :fab:`python`
-
-        .. grid-item::
-            :child-align: center
-
-            .. raw:: html
-
-               <a class="sd-btn sd-btn-primary sd-shadow"
-                  download href="{cname_pref}/{ipynb_file_loc}">
-                 Download as Jupyter notebook <i class="fas fa-book"></i>
-               </a>
-
-        .. grid-item::
-            :child-align: center
-
-            .. button-link:: {cname_pref}/{assets_loc}
-               :color: primary
-               :shadow:
-
-                Download all assets :fa:`file`
-
-        .. grid-item::
-
+    nbsphinx_epilog = """
     ----
+
+    .. admonition:: Download this example
+
+        Download this example as a `Jupyter Notebook <{cname_pref}/{ipynb_file_loc}>`_
+        or as a `Python script <{cname_pref}/{py_file_loc}>`_. All assets used in the
+        examples can be downloaded as a `ZIP archive <{cname_pref}/{assets_loc}>`_.
 
     """.format(
         cname_pref=f"https://{cname}/version/{get_version_match(version)}",
-        python_file_loc="{{ env.docname }}.py",
         ipynb_file_loc="{{ env.docname }}.ipynb",
+        py_file_loc="{{ env.docname }}.py",
+        assets_loc="_static/assets/download/assets.zip",
+    )
+    nbsphinx_prolog = """
+
+    .. admonition:: Download this example
+
+        Download this example as a `Jupyter Notebook <{cname_pref}/{ipynb_file_loc}>`_
+        or as a `Python script <{cname_pref}/{py_file_loc}>`_. All assets used in the
+        examples can be downloaded as a `ZIP archive <{cname_pref}/{assets_loc}>`_.
+
+    """.format(
+        cname_pref=f"https://{cname}/version/{get_version_match(version)}",
+        ipynb_file_loc="{{ env.docname }}.ipynb",
+        py_file_loc="{{ env.docname }}.py",
         assets_loc="_static/assets/download/assets.zip",
     )
 


### PR DESCRIPTION
## Description
Update how notebook, script and assets are proposed for download. I think it renders much better than the current approach and it should also work with PDF.

On top of that the CI has now an additional step that allows to render the PR documentation if one adds the `deploy-pr-doc` label.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
