### PR TITLE
feat: export xmp to png

### DIFF
--- a/doc/changelog.d/999.added.md
+++ b/doc/changelog.d/999.added.md
@@ -1,0 +1,1 @@
+Export xmp to png

--- a/examples/core/prism-example.py
+++ b/examples/core/prism-example.py
@@ -13,6 +13,7 @@ import os
 from pathlib import Path
 
 from ansys.speos.core import Body, Project, Speos
+from ansys.speos.core.generic.version_checker import server_version_checker
 from ansys.speos.core.kernel.client import (
     default_docker_channel,
 )
@@ -82,8 +83,9 @@ sim.compute_CPU()
 
 # Use the open_result_image method to review the result
 
-
-if os.name == "nt":
+# Method available only on Windows OS or with Speos 2026 R1.2 or higher,
+# which supports opening XMP results as images regardless of the OS.
+if os.name == "nt" or server_version_checker.is_version_supported(2026, 1, 2):
     from ansys.speos.core.workflow.open_result import open_result_image
 
     open_result_image(simulation_feature=sim, result_name="Prism.Irradiance.1.xmp")
@@ -115,7 +117,9 @@ p.preview()
 # ## Re-run the simulation with new sensor definition.
 
 sim.compute_CPU()
-if os.name == "nt":
+# Method available only on Windows OS or with Speos 2026 R1.2 or higher,
+# which supports opening XMP results as images regardless of the OS.
+if os.name == "nt" or server_version_checker.is_version_supported(2026, 1, 2):
     open_result_image(simulation_feature=sim, result_name="Prism.Irradiance.1.xmp")
 
 speos.close()

--- a/examples/core/project.py
+++ b/examples/core/project.py
@@ -19,6 +19,7 @@ import os
 from pathlib import Path
 
 from ansys.speos.core import Project, Speos
+from ansys.speos.core.generic.version_checker import server_version_checker
 from ansys.speos.core.kernel.client import (
     default_docker_channel,
 )
@@ -212,9 +213,11 @@ print(sim_feat)
 sim_feat.compute_CPU()
 # -
 
-# Preview simulation result (only windows)
+# Preview simulation result
 
-if os.name == "nt":
+# Method available only on Windows OS or with Speos 2026 R1.2 or higher,
+# which supports opening XMP results as images regardless of the OS.
+if os.name == "nt" or server_version_checker.is_version_supported(2026, 1, 2):
     from ansys.speos.core.workflow.open_result import open_result_image
 
     open_result_image(

--- a/examples/core/texture.py
+++ b/examples/core/texture.py
@@ -181,7 +181,9 @@ print(opt)
 # Image result shows black surface as mirror reflectance is 0.
 
 results = sim.compute_CPU()
-if os.name == "nt":
+# Method available only on Windows OS or with Speos 2026 R1.2 or higher,
+# which supports opening XMP results as images regardless of the OS.
+if os.name == "nt" or server_version_checker.is_version_supported(2026, 1, 2):
     from ansys.speos.core.workflow.open_result import open_result_image
 
     open_result_image(simulation_feature=sim, result_name="Radiance.xmp")
@@ -200,7 +202,9 @@ print(opt)
 # Image result shows mirror surface as mirror reflectance is 100.
 
 results = sim.compute_CPU()
-if os.name == "nt":
+# Method available only on Windows OS or with Speos 2026 R1.2 or higher,
+# which supports opening XMP results as images regardless of the OS.
+if os.name == "nt" or server_version_checker.is_version_supported(2026, 1, 2):
     from ansys.speos.core.workflow.open_result import open_result_image
 
     open_result_image(simulation_feature=sim, result_name="Radiance.xmp")
@@ -245,7 +249,9 @@ opt.commit()
 # simplescattering file.
 
 results = sim.compute_CPU()
-if os.name == "nt":
+# Method available only on Windows OS or with Speos 2026 R1.2 or higher,
+# which supports opening XMP results as images regardless of the OS.
+if os.name == "nt" or server_version_checker.is_version_supported(2026, 1, 2):
     from ansys.speos.core.workflow.open_result import open_result_image
 
     open_result_image(simulation_feature=sim, result_name="Radiance.xmp")
@@ -300,7 +306,9 @@ opt.commit()
 # transparent at the other area.
 
 results = sim.compute_CPU()
-if os.name == "nt":
+# Method available only on Windows OS or with Speos 2026 R1.2 or higher,
+# which supports opening XMP results as images regardless of the OS.
+if os.name == "nt" or server_version_checker.is_version_supported(2026, 1, 2):
     from ansys.speos.core.workflow.open_result import open_result_image
 
     open_result_image(simulation_feature=sim, result_name="Radiance.xmp")
@@ -312,7 +320,9 @@ texture_layer_3.image_texture.uv_mapping.axis_system = [0, 2.5, 0, 0, 0, 1, 0, 1
 opt.commit()
 
 results = sim.compute_CPU()  # use GPU using "compute_GPU" method
-if os.name == "nt":
+# Method available only on Windows OS or with Speos 2026 R1.2 or higher,
+# which supports opening XMP results as images regardless of the OS.
+if os.name == "nt" or server_version_checker.is_version_supported(2026, 1, 2):
     from ansys.speos.core.workflow.open_result import open_result_image
 
     open_result_image(simulation_feature=sim, result_name="Radiance.xmp")
@@ -324,7 +334,9 @@ texture_layer_3.image_texture.repeat_u = True
 opt.commit()
 
 results = sim.compute_CPU()
-if os.name == "nt":
+# Method available only on Windows OS or with Speos 2026 R1.2 or higher,
+# which supports opening XMP results as images regardless of the OS.
+if os.name == "nt" or server_version_checker.is_version_supported(2026, 1, 2):
     from ansys.speos.core.workflow.open_result import open_result_image
 
     open_result_image(simulation_feature=sim, result_name="Radiance.xmp")
@@ -336,7 +348,9 @@ texture_layer_3.image_texture.uv_mapping.v_length = 10
 opt.commit()
 
 results = sim.compute_CPU()
-if os.name == "nt":
+# Method available only on Windows OS or with Speos 2026 R1.2 or higher,
+# which supports opening XMP results as images regardless of the OS.
+if os.name == "nt" or server_version_checker.is_version_supported(2026, 1, 2):
     from ansys.speos.core.workflow.open_result import open_result_image
 
     open_result_image(simulation_feature=sim, result_name="Radiance.xmp")
@@ -407,7 +421,9 @@ opt_2_layer_1.image_texture.repeat_v = False
 opt_2.commit()
 
 results = sim.compute_CPU()
-if os.name == "nt":
+# Method available only on Windows OS or with Speos 2026 R1.2 or higher,
+# which supports opening XMP results as images regardless of the OS.
+if os.name == "nt" or server_version_checker.is_version_supported(2026, 1, 2):
     from ansys.speos.core.workflow.open_result import open_result_image
 
     open_result_image(simulation_feature=sim, result_name="Radiance.xmp")
@@ -446,7 +462,9 @@ opt_2_layer_1.image_texture.uv_mapping.vertices_data_index = 1
 opt_2.commit()
 
 results = sim.compute_CPU()
-if os.name == "nt":
+# Method available only on Windows OS or with Speos 2026 R1.2 or higher,
+# which supports opening XMP results as images regardless of the OS.
+if os.name == "nt" or server_version_checker.is_version_supported(2026, 1, 2):
     from ansys.speos.core.workflow.open_result import open_result_image
 
     open_result_image(simulation_feature=sim, result_name="Radiance.xmp")
@@ -481,7 +499,9 @@ opt_2_layer_1.image_texture.uv_mapping.vertices_data_index = 2
 opt_2.commit()
 
 results = sim.compute_CPU()
-if os.name == "nt":
+# Method available only on Windows OS or with Speos 2026 R1.2 or higher,
+# which supports opening XMP results as images regardless of the OS.
+if os.name == "nt" or server_version_checker.is_version_supported(2026, 1, 2):
     from ansys.speos.core.workflow.open_result import open_result_image
 
     open_result_image(simulation_feature=sim, result_name="Radiance.xmp")
@@ -587,7 +607,9 @@ opt_3_layer_1.image_texture.repeat_v = False
 opt_3.commit()
 
 results = sim.compute_CPU()
-if os.name == "nt":
+# Method available only on Windows OS or with Speos 2026 R1.2 or higher,
+# which supports opening XMP results as images regardless of the OS.
+if os.name == "nt" or server_version_checker.is_version_supported(2026, 1, 2):
     from ansys.speos.core.workflow.open_result import open_result_image
 
     open_result_image(simulation_feature=sim, result_name="Radiance.xmp")

--- a/examples/workflow/combine-speos.py
+++ b/examples/workflow/combine-speos.py
@@ -10,6 +10,7 @@ import os
 from pathlib import Path
 
 from ansys.speos.core import Part, Speos, launcher
+from ansys.speos.core.generic.version_checker import server_version_checker
 from ansys.speos.core.kernel.client import (
     default_docker_channel,
 )
@@ -171,9 +172,11 @@ run_sim()  # Run the simulation
 
 # ## Check and review result
 #
-# Open result (only windows)
+# Open result
 
-if os.name == "nt":
+# Method available only on Windows OS or with Speos 2026 R1.2 or higher,
+# which supports opening XMP results as images regardless of the OS.
+if os.name == "nt" or server_version_checker.is_version_supported(2026, 1, 2):
     from ansys.speos.core.workflow.open_result import open_result_image
 
     open_result_image(simulation_feature=sim, result_name="Camera.1.png")
@@ -198,7 +201,9 @@ run_sim()
 
 # Review result:
 
-if os.name == "nt":
+# Method available only on Windows OS or with Speos 2026 R1.2 or higher,
+# which supports opening XMP results as images regardless of the OS.
+if os.name == "nt" or server_version_checker.is_version_supported(2026, 1, 2):
     open_result_image(simulation_feature=sim, result_name="Camera.1.png")
 
 # ## Modify camera property
@@ -212,7 +217,9 @@ cam1.commit()
 # Re-run the simulation and review result
 
 run_sim()
-if os.name == "nt":
+# Method available only on Windows OS or with Speos 2026 R1.2 or higher,
+# which supports opening XMP results as images regardless of the OS.
+if os.name == "nt" or server_version_checker.is_version_supported(2026, 1, 2):
     open_result_image(simulation_feature=sim, result_name="Camera.1.png")
 
 speos.close()

--- a/examples/workflow/open-result.py
+++ b/examples/workflow/open-result.py
@@ -84,7 +84,7 @@ print(results)
 
 
 # ## Postprocessing
-# ### Open the results (MS Windows OS only):
+# ### Open the results:
 #
 # Display one result as image.
 #

--- a/examples/workflow/open-result.py
+++ b/examples/workflow/open-result.py
@@ -11,6 +11,7 @@ import os
 from pathlib import Path
 
 from ansys.speos.core import Project, Speos, launcher
+from ansys.speos.core.generic.version_checker import server_version_checker
 from ansys.speos.core.kernel.client import (
     default_docker_channel,
 )
@@ -89,7 +90,9 @@ print(results)
 #
 # A full path can be given, or the name of the result.
 
-if os.name == "nt":  # Are we running on Windows OS?
+# Method available only on Windows OS or with Speos 2026 R1.2 or higher,
+# which supports opening XMP results as images regardless of the OS.
+if os.name == "nt" or server_version_checker.is_version_supported(2026, 1, 2):
     from ansys.speos.core.workflow.open_result import open_result_image
 
     open_result_image(simulation_feature=sim, result_name=RESULT_NAME)
@@ -107,4 +110,23 @@ if os.name == "nt":
         simulation_feature=sim,
         result_name=RESULT_NAME,
     )
+
+
+# ### Export the XMP result to PNG image
+#
+# Export one result to a PNG image file.
+#
+# A full path can be given, or the name of the result.
+
+from ansys.speos.core.workflow.open_result import export_xmp_to_image
+
+exported_image = export_xmp_to_image(simulation_feature=sim, result_name=RESULT_NAME)
+if exported_image.HasField("path"):
+    print(exported_image.path)  # Local path of the exported image on the server.
+elif exported_image.HasField("upload_response"):
+    print(
+        exported_image.upload_response.info.uri
+    )  # URI of the exported image on the server, which can be used to download the file.
+
+
 speos.close()

--- a/src/ansys/speos/core/kernel/client.py
+++ b/src/ansys/speos/core/kernel/client.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, List, Optional, Union
 from ansys.api.speos.part.v1 import body_pb2, face_pb2, part_pb2
 
 from ansys.speos.core.generic.version_checker import server_version_checker
+from ansys.speos.core.kernel.map import MapStub
 
 try:
     from ansys.api.speos.server_info.v1 import server_info_pb2, server_info_pb2_grpc
@@ -247,6 +248,7 @@ class SpeosClient:
         self._simulationTemplateDB = None
         self._sceneDB = None
         self._jobDB = None
+        self._maps = None
 
     @property
     def channel(self) -> grpc.Channel:
@@ -370,6 +372,14 @@ class SpeosClient:
         if self._jobDB is None:
             self._jobDB = JobStub(self._channel)
         return self._jobDB
+
+    def maps(self) -> MapStub:
+        """Get map actions access."""
+        self.__closed_error()
+        # connect to database
+        if self._maps is None:
+            self._maps = MapStub(self._channel)
+        return self._maps
 
     def __closed_error(self):
         """Check if closed."""

--- a/src/ansys/speos/core/kernel/map.py
+++ b/src/ansys/speos/core/kernel/map.py
@@ -29,6 +29,8 @@ from ansys.api.speos.results.v1 import (
     map_pb2_grpc as service,
 )
 
+from ansys.speos.core.generic.version_checker import server_version_checker
+
 
 class MapStub:
     """
@@ -51,6 +53,10 @@ class MapStub:
     """
 
     def __init__(self, channel):
+        if not server_version_checker.is_version_supported(2026, 1, 2):
+            raise NotImplementedError(
+                "Map actions are only supported with Speos 2026 R1.2 or higher."
+            )
         self._actions_stub = service.MapActionsStub(channel=channel)
 
     # Actions

--- a/src/ansys/speos/core/kernel/map.py
+++ b/src/ansys/speos/core/kernel/map.py
@@ -1,0 +1,72 @@
+# Copyright (C) 2021 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Provides a wrapped abstraction of the gRPC proto API definition and stubs."""
+
+from pathlib import Path
+
+from ansys.api.speos.results.v1 import (
+    map_pb2 as messages,
+    map_pb2_grpc as service,
+)
+
+
+class MapStub:
+    """
+    Database interactions for map actions.
+
+    Parameters
+    ----------
+    channel : grpc.Channel
+        Channel to use for the stub.
+
+    Examples
+    --------
+    The best way to get a MapStub is to retrieve it from SpeosClient via
+    maps() method. Like in the following example:
+
+    >>> from ansys.speos.core.speos import Speos
+    >>> speos = Speos()
+    >>> map_db = speos.client.maps()
+
+    """
+
+    def __init__(self, channel):
+        self._actions_stub = service.MapActionsStub(channel=channel)
+
+    # Actions
+    def export_xmp_to_image(self, xmp_file_uri: Path | str, image_file_uri: Path | str) -> None:
+        """
+        Export XMP file to PNG file.
+
+        Parameters
+        ----------
+        xmp_file_uri : Path | str
+            XMP file to be exported.
+        image_file_uri : Path | str
+            PNG file to be created.
+        """
+        self._actions_stub.ExportXMPToImage(
+            messages.ExportXMPToImage_Request(
+                xmp_file_uri=str(xmp_file_uri), image_file_uri=str(image_file_uri)
+            )
+        )

--- a/src/ansys/speos/core/workflow/open_result.py
+++ b/src/ansys/speos/core/workflow/open_result.py
@@ -32,6 +32,8 @@ from ansys.api.speos.part.v1 import face_pb2
 
 from ansys.speos.core.generic.file_transfer import FileTransfer
 from ansys.speos.core.generic.general_methods import normalize_vector
+from ansys.speos.core.generic.version_checker import server_version_checker
+from ansys.speos.core.kernel import SpeosClient
 from ansys.speos.core.sensor import SensorIrradiance, SensorRadiance
 
 if os.name == "nt":
@@ -112,38 +114,81 @@ def _display_image(img: numpy.ndarray):
         plt.show()
 
 
-if os.name == "nt":
+def open_result_image(
+    simulation_feature: Union[SimulationDirect, SimulationInverse, SimulationInteractive],
+    result_name: str,
+) -> Path:
+    """Retrieve an image from a specific simulation result.
 
-    def open_result_image(
-        simulation_feature: Union[SimulationDirect, SimulationInverse, SimulationInteractive],
-        result_name: str,
-    ) -> None:
-        """Retrieve an image from a specific simulation result.
+    Parameters
+    ----------
+    simulation_feature : ansys.speos.core.simulation.Simulation
+        The simulation feature.
+    result_name : str
+        The result name to open as an image.
 
-        Parameters
-        ----------
-        simulation_feature : ansys.speos.core.simulation.Simulation
-            The simulation feature.
-        result_name : str
-            The result name to open as an image.
-        """
-        file_path = _find_correct_result(simulation_feature, result_name)
-        if file_path == "":
-            raise ValueError(
-                "No result corresponding to "
-                + result_name
-                + " is found in "
-                + simulation_feature._name
+    Returns
+    -------
+    Path
+        The path of the image file.
+    """
+    download_if_distant = True
+    # In case of XMP that will be exported to PNG by the server,
+    # it is important not to download locally the XMP file.
+    if result_name.lower().endswith("xmp") and server_version_checker.is_version_supported(
+        2026, 1, 2
+    ):
+        download_if_distant = False
+
+    file_path = _find_correct_result(
+        simulation_feature, result_name, download_if_distant=download_if_distant
+    )
+    if file_path == "":
+        raise ValueError(
+            "No result corresponding to " + result_name + " is found in " + simulation_feature._name
+        )
+
+    if result_name.lower().endswith("xmp"):
+        if server_version_checker.is_version_supported(2026, 1, 2):
+            res = _export_xmp_to_image(
+                client=simulation_feature._project.client,
+                file_path=file_path,
+                result_name=result_name,
             )
-
-        if file_path.endswith("xmp") or file_path.endswith("XMP"):
+            if res.HasField("path"):
+                _display_image(mpimg.imread(res.path))
+                return Path(res.path)
+            elif res.HasField("upload_response"):
+                file_transfer = FileTransfer(simulation_feature._project.client)
+                file_transfer.download_file(
+                    file_uri=res.upload_response.info.uri,
+                    download_location=Path(tempfile.gettempdir()),
+                )
+                downloaded_file_path = (
+                    Path(tempfile.gettempdir()) / res.upload_response.info.file_name
+                )
+                _display_image(mpimg.imread(str(downloaded_file_path)))
+                return downloaded_file_path
+        elif os.name == "nt":  # Are we running on Windows OS?
             dpf_instance = CreateObject("XMPViewer.Application")
             dpf_instance.OpenFile(file_path)
             res = dpf_instance.ExportXMPImage(file_path + ".png", 1)
             if res:
                 _display_image(mpimg.imread(file_path + ".png"))
-        elif file_path.endswith("png") or file_path.endswith("PNG"):
-            _display_image(mpimg.imread(file_path))
+                return Path(file_path + ".png")
+        else:
+            raise NotImplementedError(
+                "Opening XMP result as image is only supported with Speos 2026 R1.2 or higher.\
+                    Or on Windows OS with older Speos versions."
+            )
+    elif result_name.lower().endswith("png"):
+        _display_image(mpimg.imread(file_path))
+        return Path(file_path)
+
+    return Path()
+
+
+if os.name == "nt":
 
     def open_result_in_viewer(
         simulation_feature: Union[SimulationDirect, SimulationInverse],
@@ -434,6 +479,33 @@ if os.name == "nt":
         return file_path.with_suffix(".vtp")
 
 
+def _export_xmp_to_image(client: SpeosClient, file_path: str, result_name: str) -> Result:
+
+    # Looking at file_path allows to know if server is distant.
+    # Example: if file_path is a file_uri from file transfer -> this is a distant server,
+    # if file_path is a local path -> this is a local server.
+    is_local_server = Path(file_path).is_file() is True
+
+    image_exported_path = ""
+    if is_local_server:
+        image_exported_path = Path(file_path).with_suffix(".png")
+    else:
+        # Book a file_uri
+        file_transfer = FileTransfer(client)
+        image_exported_path = file_transfer.reserve()
+
+    client.maps().export_xmp_to_image(xmp_file_uri=file_path, image_file_uri=image_exported_path)
+
+    image_exported = Result()
+    if is_local_server:
+        image_exported.path = str(image_exported_path)
+    else:
+        image_exported.upload_response.info.uri = image_exported_path
+        image_exported.upload_response.info.file_name = Path(result_name).with_suffix(".png").name
+
+    return image_exported
+
+
 def export_xmp_to_image(
     simulation_feature: Union[SimulationDirect, SimulationInverse, SimulationInteractive],
     result_name: str,
@@ -460,34 +532,17 @@ def export_xmp_to_image(
             please provide a valid result name ending with .xmp"
         )
 
+    if not server_version_checker.is_version_supported(2026, 1, 2):
+        raise NotImplementedError(
+            "Exporting XMP result as image is only supported with Speos 2026 R1.2 or higher."
+        )
+
     file_path = _find_correct_result(simulation_feature, result_name, download_if_distant=False)
     if file_path == "":
         raise ValueError(
             "No result corresponding to " + result_name + " is found in " + simulation_feature._name
         )
 
-    # Looking at file_path allows to know if server is distant.
-    # Example: if file_path is a file_uri from file transfer -> this is a distant server,
-    # if file_path is a local path -> this is a local server.
-    is_local_server = Path(file_path).is_file() is True
-
-    image_exported_path = ""
-    if is_local_server:
-        image_exported_path = Path(file_path).with_suffix(".png")
-    else:
-        # Book a file_uri
-        file_transfer = FileTransfer(simulation_feature._project.client)
-        image_exported_path = file_transfer.reserve()
-
-    simulation_feature._project.client.maps().export_xmp_to_image(
-        xmp_file_uri=file_path, image_file_uri=image_exported_path
+    return _export_xmp_to_image(
+        client=simulation_feature._project.client, file_path=file_path, result_name=result_name
     )
-
-    image_exported = Result()
-    if is_local_server:
-        image_exported.path = str(image_exported_path)
-    else:
-        image_exported.upload_response.info.uri = image_exported_path
-        image_exported.upload_response.info.file_name = Path(result_name).with_suffix(".png").name
-
-    return image_exported

--- a/src/ansys/speos/core/workflow/open_result.py
+++ b/src/ansys/speos/core/workflow/open_result.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import tempfile
 from typing import List, Union
 
+from ansys.api.speos.job.v2.job_pb2 import Result
 from ansys.api.speos.part.v1 import face_pb2
 
 from ansys.speos.core.generic.file_transfer import FileTransfer
@@ -431,3 +432,62 @@ if os.name == "nt":
         # vtp_meshes = vtp_meshes.point_data_to_cell_data()
         vtp_meshes.save(str(file_path.with_suffix(".vtp")))
         return file_path.with_suffix(".vtp")
+
+
+def export_xmp_to_image(
+    simulation_feature: Union[SimulationDirect, SimulationInverse, SimulationInteractive],
+    result_name: str,
+) -> Result:
+    """Export an XMP result into a PNG file.
+
+    Parameters
+    ----------
+    simulation_feature : ansys.speos.core.simulation.Simulation
+        The simulation feature.
+    result_name : str
+        The result name to export as an image.
+
+    Returns
+    -------
+    ansys.api.speos.job.v2.job_pb2.Result
+        The exported image file.
+    """
+    if not str(result_name).lower().endswith(".xmp"):
+        # raise error if the result name does not end with .xmp,
+        # since only xmp result can be exported to image
+        raise ValueError(
+            "Only XMP result can be exported to image,\
+            please provide a valid result name ending with .xmp"
+        )
+
+    file_path = _find_correct_result(simulation_feature, result_name, download_if_distant=False)
+    if file_path == "":
+        raise ValueError(
+            "No result corresponding to " + result_name + " is found in " + simulation_feature._name
+        )
+
+    # Looking at file_path allows to know if server is distant.
+    # Example: if file_path is a file_uri from file transfer -> this is a distant server,
+    # if file_path is a local path -> this is a local server.
+    is_local_server = Path(file_path).is_file() is True
+
+    image_exported_path = ""
+    if is_local_server:
+        image_exported_path = Path(file_path).with_suffix(".png")
+    else:
+        # Book a file_uri
+        file_transfer = FileTransfer(simulation_feature._project.client)
+        image_exported_path = file_transfer.reserve()
+
+    simulation_feature._project.client.maps().export_xmp_to_image(
+        xmp_file_uri=file_path, image_file_uri=image_exported_path
+    )
+
+    image_exported = Result()
+    if is_local_server:
+        image_exported.path = str(image_exported_path)
+    else:
+        image_exported.upload_response.info.uri = image_exported_path
+        image_exported.upload_response.info.file_name = Path(result_name).with_suffix(".png").name
+
+    return image_exported

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,7 +102,7 @@ def speos():
 # set test_path var depending on if we are using the servers in a docker container or not
 local_test_path = local_path / "assets"
 if IS_DOCKER:
-    test_path = "/app/assets/"
+    test_path = Path("/app/assets/")
 else:
     test_path = local_test_path
 

--- a/tests/kernel/test_map.py
+++ b/tests/kernel/test_map.py
@@ -22,11 +22,14 @@
 
 """Test map actions."""
 
+import pytest
+
 from ansys.speos.core.speos import Speos
 from tests.conftest import test_path
 import tests.helper as helper
 
 
+@pytest.mark.supported_speos_versions(min=261)
 def test_export_xmp_to_image(speos: Speos):
     """Test the export of XMP to PNG."""
     assert speos.client.healthy is True

--- a/tests/kernel/test_map.py
+++ b/tests/kernel/test_map.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2021 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Test map actions."""
+
+from ansys.speos.core.speos import Speos
+from tests.conftest import test_path
+import tests.helper as helper
+
+
+def test_export_xmp_to_image(speos: Speos):
+    """Test the export of XMP to PNG."""
+    assert speos.client.healthy is True
+
+    xmp_path = test_path / "Source.speos" / "PROJECT.Direct-no-Ray.Irradiance Ray Spectral.xmp"
+    png_exported = test_path / "testExported.png"
+
+    map_stub = speos.client.maps()
+    map_stub.export_xmp_to_image(xmp_file_uri=xmp_path, image_file_uri=png_exported)
+
+    assert helper.does_file_exist(png_exported) is True
+    helper.remove_file(png_exported)

--- a/tests/workflow/test_open_result.py
+++ b/tests/workflow/test_open_result.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2021 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Test using combine_speos module in workflow layer."""
+
+from pathlib import Path
+
+from ansys.speos.core.generic.file_transfer import FileTransfer
+from ansys.speos.core.project import Project
+from ansys.speos.core.simulation import SimulationDirect
+from ansys.speos.core.speos import Speos
+from ansys.speos.core.workflow.open_result import export_xmp_to_image
+from tests.conftest import local_test_path, test_path
+
+
+def test_export_xmp_to_image(speos: Speos):
+    """Test exporting XMP file to image."""
+    p = Project(
+        speos=speos,
+        path=test_path / "LG_50M_Colorimetric_short.sv5" / "LG_50M_Colorimetric_short.sv5",
+    )
+    sim_feat: SimulationDirect = p.find(name=".*", name_regex=True, feature_type=SimulationDirect)[
+        0
+    ]
+    results = sim_feat.compute_CPU()
+    print(results)
+
+    # Look for the first XMP file encountered.
+    xmp_name_to_export = Path()
+    for result in results:
+        if result.HasField("path") and result.path.endswith(".xmp"):
+            xmp_name_to_export = Path(result.path).name
+            break
+        elif result.HasField("upload_response") and result.upload_response.info.file_name.endswith(
+            ".xmp"
+        ):
+            xmp_name_to_export = result.upload_response.info.file_name
+            break
+
+    image_exported = export_xmp_to_image(
+        simulation_feature=sim_feat, result_name=xmp_name_to_export
+    )
+    if image_exported.HasField("path"):
+        downloaded_image = Path(image_exported.path)
+        assert downloaded_image.is_file() is True
+        downloaded_image.unlink()
+    elif image_exported.HasField("upload_response"):
+        file_transfer = FileTransfer(speos.client)
+        file_transfer.download_file(
+            file_uri=image_exported.upload_response.info.uri, download_location=local_test_path
+        )
+        downloaded_image = local_test_path / image_exported.upload_response.info.file_name
+        assert downloaded_image.is_file() is True
+        downloaded_image.unlink()

--- a/tests/workflow/test_open_result.py
+++ b/tests/workflow/test_open_result.py
@@ -24,14 +24,17 @@
 
 from pathlib import Path
 
+import pytest
+
 from ansys.speos.core.generic.file_transfer import FileTransfer
 from ansys.speos.core.project import Project
 from ansys.speos.core.simulation import SimulationDirect
 from ansys.speos.core.speos import Speos
-from ansys.speos.core.workflow.open_result import export_xmp_to_image
+from ansys.speos.core.workflow.open_result import export_xmp_to_image, open_result_image
 from tests.conftest import local_test_path, test_path
 
 
+@pytest.mark.supported_speos_versions(min=261)
 def test_export_xmp_to_image(speos: Speos):
     """Test exporting XMP file to image."""
     p = Project(
@@ -71,3 +74,35 @@ def test_export_xmp_to_image(speos: Speos):
         downloaded_image = local_test_path / image_exported.upload_response.info.file_name
         assert downloaded_image.is_file() is True
         downloaded_image.unlink()
+
+
+@pytest.mark.supported_speos_versions(min=261)
+def test_open_result_image(speos: Speos):
+    """Test opening result as an image."""
+    p = Project(
+        speos=speos,
+        path=test_path / "LG_50M_Colorimetric_short.sv5" / "LG_50M_Colorimetric_short.sv5",
+    )
+    sim_feat: SimulationDirect = p.find(name=".*", name_regex=True, feature_type=SimulationDirect)[
+        0
+    ]
+    results = sim_feat.compute_CPU()
+    print(results)
+
+    # Look for the first XMP file encountered.
+    xmp_name_to_export = Path()
+    for result in results:
+        if result.HasField("path") and result.path.endswith(".xmp"):
+            xmp_name_to_export = Path(result.path).name
+            break
+        elif result.HasField("upload_response") and result.upload_response.info.file_name.endswith(
+            ".xmp"
+        ):
+            xmp_name_to_export = result.upload_response.info.file_name
+            break
+
+    image_exported_path = open_result_image(
+        simulation_feature=sim_feat, result_name=xmp_name_to_export
+    )
+    assert image_exported_path.is_file() is True
+    image_exported_path.unlink()

--- a/tests/workflow/test_open_result.py
+++ b/tests/workflow/test_open_result.py
@@ -30,7 +30,7 @@ from ansys.speos.core.generic.file_transfer import FileTransfer
 from ansys.speos.core.project import Project
 from ansys.speos.core.simulation import SimulationDirect
 from ansys.speos.core.speos import Speos
-from ansys.speos.core.workflow.open_result import export_xmp_to_image, open_result_image
+from ansys.speos.core.workflow.open_result import export_xmp_to_image
 from tests.conftest import local_test_path, test_path
 
 
@@ -74,35 +74,3 @@ def test_export_xmp_to_image(speos: Speos):
         downloaded_image = local_test_path / image_exported.upload_response.info.file_name
         assert downloaded_image.is_file() is True
         downloaded_image.unlink()
-
-
-@pytest.mark.supported_speos_versions(min=261)
-def test_open_result_image(speos: Speos):
-    """Test opening result as an image."""
-    p = Project(
-        speos=speos,
-        path=test_path / "LG_50M_Colorimetric_short.sv5" / "LG_50M_Colorimetric_short.sv5",
-    )
-    sim_feat: SimulationDirect = p.find(name=".*", name_regex=True, feature_type=SimulationDirect)[
-        0
-    ]
-    results = sim_feat.compute_CPU()
-    print(results)
-
-    # Look for the first XMP file encountered.
-    xmp_name_to_export = Path()
-    for result in results:
-        if result.HasField("path") and result.path.endswith(".xmp"):
-            xmp_name_to_export = Path(result.path).name
-            break
-        elif result.HasField("upload_response") and result.upload_response.info.file_name.endswith(
-            ".xmp"
-        ):
-            xmp_name_to_export = result.upload_response.info.file_name
-            break
-
-    image_exported_path = open_result_image(
-        simulation_feature=sim_feat, result_name=xmp_name_to_export
-    )
-    assert image_exported_path.is_file() is True
-    image_exported_path.unlink()


### PR DESCRIPTION
## Description
Kernel and Workflow levels
Add possibility to export xmp into png.

For workflow level, it is available via:
from ansys.speos.core.workflow.open_result import export_xmp_to_image
export_xmp_to_image(simulation_feature=..., result_name=...)

**Also used in the existing method open_result_image.**

For kernel level, it is available via:
map_stub = speos.client.maps()
map_stub.export_xmp_to_image(xmp_file_uri=..., image_file_uri=...)

## Issue linked

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
