### PR TITLE
chore: bump dev version into v0.10.dev0

### DIFF
--- a/doc/changelog.d/1017.maintenance.md
+++ b/doc/changelog.d/1017.maintenance.md
@@ -1,0 +1,1 @@
+Bump dev version into v0.10.dev0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "ansys-speos-core"
-version = "0.8.dev0"
+version = "0.10.dev0"
 description = "A Python wrapper for Ansys Speos"
 readme = "README.rst"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Description
As title says. Seems like there was a miss in the previous minor release to bump this.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
