### PR TITLE
ci: fix reusable action's python setup

### DIFF
--- a/.github/workflows/reusable-speos-tests.yml
+++ b/.github/workflows/reusable-speos-tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/doc/changelog.d/1026.maintenance.md
+++ b/doc/changelog.d/1026.maintenance.md
@@ -1,0 +1,1 @@
+Fix reusable action's python setup


### PR DESCRIPTION
## Description
When refactoring the CI to leverage a reusable workflow, a reference to a modified env variable was still here. This correctly uses the provided inputs through matrix.

## Issue linked
None but detected issue in nightly runs

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
