### PR TITLE
test: temporary update marker for 261

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -292,7 +292,7 @@ jobs:
       packages: read   # Required to pull images from GitHub Container Registry (ghcr.io)
     with:
       python-versions: '["3.14"]'
-      speos-versions: '["dev", "261"]'
+      speos-versions: '["dev"]'
     secrets:
       LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -292,7 +292,7 @@ jobs:
       packages: read   # Required to pull images from GitHub Container Registry (ghcr.io)
     with:
       python-versions: '["3.14"]'
-      speos-versions: '["dev"]'
+      speos-versions: '["dev", "261"]'
     secrets:
       LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/doc/changelog.d/1071.test.md
+++ b/doc/changelog.d/1071.test.md
@@ -1,0 +1,1 @@
+Temporary update marker for 261

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -796,7 +796,7 @@ def test_create_speos_feature_preview_sensor_radiance(speos: Speos):
     assert mock_plotter.plot.call_count >= 3
 
 
-@pytest.mark.supported_speos_versions(min=252)
+@pytest.mark.supported_speos_versions(min=261.3)
 def test_create_speos_feature_preview_sensor_camera(speos: Speos):
     """Test _create_speos_feature_preview for SensorCamera (case _: branch, 3-axis coords)."""
     p = Project(speos=speos)

--- a/tests/core/test_sensor.py
+++ b/tests/core/test_sensor.py
@@ -83,7 +83,7 @@ from ansys.speos.core.simulation import SimulationDirect
 from tests.conftest import test_path
 
 
-@pytest.mark.supported_speos_versions(min=252)
+@pytest.mark.supported_speos_versions(min=261.3)
 def test_create_camera_sensor(speos: Speos):
     """Test creation of camera sensor."""
     p = Project(speos=speos)
@@ -2106,7 +2106,7 @@ def test_radiance_modify_after_reset(speos: Speos):
     sensor1.delete()
 
 
-@pytest.mark.supported_speos_versions(min=251)
+@pytest.mark.supported_speos_versions(min=261.3)
 def test_camera_modify_after_reset(speos: Speos):
     """Test reset of camera sensor, and then modify."""
     p = Project(speos=speos)
@@ -2307,6 +2307,7 @@ def test_delete_sensor(speos: Speos):
     assert sensor1._sensor_instance.HasField("irradiance_properties")  # local
 
 
+@pytest.mark.supported_speos_versions(min=261.3)
 def test_get_sensor(speos: Speos, capsys: pytest.CaptureFixture[str]):
     """Test get of a sensor."""
     p = Project(speos=speos)
@@ -2951,7 +2952,7 @@ def test_load_immersive_sensor_from_speos_file(speos: Speos):
     assert sensor._sensor_instance.immersive_properties.HasField("layer_type_none")
 
 
-@pytest.mark.supported_speos_versions(min=252)
+@pytest.mark.supported_speos_versions(min=261.3)
 def test_load_camera_hydrates_nested_modes(speos: Speos):
     """Ensure camera load path hydrates photometric and nested color balance helpers."""
     p = Project(speos=speos)
@@ -3044,7 +3045,7 @@ def test_load_irradiance_3d_hydrates_radial_integration_helpers(speos: Speos):
     sensor_photo.delete()
 
 
-@pytest.mark.supported_speos_versions(min=252)
+@pytest.mark.supported_speos_versions(min=261.3)
 def test_load_camera_hydrates_geometric_mode(speos: Speos):
     """Ensure camera load path hydrates geometric mode branch."""
     p = Project(speos=speos)
@@ -3071,7 +3072,7 @@ def test_load_camera_hydrates_geometric_mode(speos: Speos):
     sensor_camera.delete()
 
 
-@pytest.mark.supported_speos_versions(min=252)
+@pytest.mark.supported_speos_versions(min=261.3)
 @pytest.mark.parametrize(
     ("balance_setter", "expected_field", "expected_mode_type"),
     [
@@ -3197,7 +3198,7 @@ def test_load_irradiance_3d_hydrates_planar_integration_helpers(speos: Speos):
     assert loaded_radiometric.radiometric._integration_type.absorption is True
 
 
-@pytest.mark.supported_speos_versions(min=261)
+@pytest.mark.supported_speos_versions(min=261.3)
 def test_camera_photometric_consider_diffraction_effects_default(speos: Speos):
     """Test default value of consider_diffraction_effects is False."""
     p = Project(speos=speos)
@@ -3209,7 +3210,7 @@ def test_camera_photometric_consider_diffraction_effects_default(speos: Speos):
     assert sensor.set_mode_photometric().consider_diffraction_effects is False
 
 
-@pytest.mark.supported_speos_versions(min=261)
+@pytest.mark.supported_speos_versions(min=261.3)
 def test_camera_photometric_consider_diffraction_effects_setter(speos: Speos):
     """Test consider_diffraction_effects setter and getter."""
     p = Project(speos=speos)
@@ -3226,7 +3227,7 @@ def test_camera_photometric_consider_diffraction_effects_setter(speos: Speos):
     assert sensor.set_mode_photometric().consider_diffraction_effects is False
 
 
-@pytest.mark.supported_speos_versions(min=261)
+@pytest.mark.supported_speos_versions(min=261.3)
 def test_camera_photometric_consider_diffraction_effects_persistence(speos: Speos):
     """Test consider_diffraction_effects persists after commit and reset."""
     p = Project(speos=speos)
@@ -3266,7 +3267,7 @@ def test_camera_photometric_consider_diffraction_effects_persistence(speos: Speo
     sensor.delete()
 
 
-@pytest.mark.supported_speos_versions(min=261)
+@pytest.mark.supported_speos_versions(min=261.3)
 def test_camera_photometric_consider_diffraction_effects_from_parameters(speos: Speos):
     """Test consider_diffraction_effects from PhotometricCameraParameters."""
     p = Project(speos=speos)


### PR DESCRIPTION
## Description
Following #1062 the nightly run are failing when running with 26R1, see [here](https://github.com/ansys/pyspeos/actions/runs/29889948260/job/88828199124). This PR temporarily updates the marker to fix that.

I think a deeper change should be performed in how new features should be added to the code base while minimizing breaks on older version of speos (if possible). Users could still be using previous version of `pyspeos` for sure but it would be great to be able to deliver new releases with backward compatibility.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
