### PR TITLE
fix: backwardscompatibility

### DIFF
--- a/doc/changelog.d/1076.fixed.md
+++ b/doc/changelog.d/1076.fixed.md
@@ -1,0 +1,1 @@
+Backwardscompatibility

--- a/src/ansys/speos/core/sensor.py
+++ b/src/ansys/speos/core/sensor.py
@@ -1742,7 +1742,10 @@ class SensorCamera(BaseSensor):
                 self.acquisition_integration = default_parameters.acquisition_integration_time
                 self.acquisition_lag_time = default_parameters.acquisition_lag_time
                 self.gamma_correction = default_parameters.gamma_correction
-                self.consider_diffraction_effects = default_parameters.consider_diffraction_effects
+                if self._mode_photometric.HasField("consider_diffraction_effects"):
+                    self.consider_diffraction_effects = (
+                        default_parameters.consider_diffraction_effects
+                    )
                 if default_parameters.transmittance_file_uri:
                     self.transmittance_file_uri = default_parameters.transmittance_file_uri
                 match default_parameters.png_bits:

--- a/src/ansys/speos/core/sensor.py
+++ b/src/ansys/speos/core/sensor.py
@@ -1742,7 +1742,7 @@ class SensorCamera(BaseSensor):
                 self.acquisition_integration = default_parameters.acquisition_integration_time
                 self.acquisition_lag_time = default_parameters.acquisition_lag_time
                 self.gamma_correction = default_parameters.gamma_correction
-                if self._mode_photometric.HasField("consider_diffraction_effects"):
+                if hasattr(self._mode_photometric, "consider_diffraction_effects"):
                     self.consider_diffraction_effects = (
                         default_parameters.consider_diffraction_effects
                     )

--- a/src/ansys/speos/core/simulation.py
+++ b/src/ansys/speos/core/simulation.py
@@ -522,9 +522,6 @@ class BaseSimulation:
                 )
         self._simulation_instance.source_paths[:] = src_paths
 
-    @min_speos_version(
-        MIN_SOURCE_GROUPS_VERSION[0], MIN_SOURCE_GROUPS_VERSION[1], MIN_SOURCE_GROUPS_VERSION[2]
-    )
     def _normalize_source_paths(self, source_paths: List[Union[str, BaseSource]]) -> List[str]:
         """Normalize source path values to their string representation.
 

--- a/tests/core/test_simulation.py
+++ b/tests/core/test_simulation.py
@@ -1280,8 +1280,8 @@ def test_stop_computation(speos: Speos):
     # Retrieve simulation feature
     sim_feature = p.find(name=".*", name_regex=True, feature_type=SimulationDirect)[0]
 
-    # Choose the stop condition of 60 s
-    sim_feature.stop_condition_duration = 60
+    # Choose the stop condition of 100 s
+    sim_feature.stop_condition_duration = 100
     sim_feature.stop_condition_rays_number = None  # No condition about rays number
     sim_feature.commit()
 
@@ -1302,7 +1302,7 @@ def test_stop_computation(speos: Speos):
     # Check that the thread is joined much before 60s (due to computation stop)
     after = datetime.datetime.now()
     difference = after - before
-    assert difference.seconds < 25
+    assert difference.seconds < 30
 
 
 @pytest.mark.supported_speos_versions(min=261)


### PR DESCRIPTION
## Description
An issue was identified which prevented to run the later pyspeos version with 261 SP0-SP2

## Issue linked

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
