### PR TITLE
fix: core layer - Simulation feature - Correct docstring and naming for set_texture_xxx methods

### DIFF
--- a/doc/changelog.d/1077.fixed.md
+++ b/doc/changelog.d/1077.fixed.md
@@ -1,0 +1,1 @@
+Core layer - Simulation feature - Correct docstring and naming for set_texture_xxx methods

--- a/src/ansys/speos/core/simulation.py
+++ b/src/ansys/speos/core/simulation.py
@@ -872,16 +872,14 @@ class BaseSimulation:
             case simulation_template_pb2.Texture.TEXTURE_NORMALIZATION_COLOR_FROM_BSDF:
                 return TextureNormalizationTypes.color_from_bsdf
 
-    def set_texture_normalization_unspecified(self) -> BaseSimulation:
-        """Set texture normalization to unspecified."""
+    def set_texture_disabled(self) -> BaseSimulation:
+        """Disable texture handling."""
         template = getattr(self._simulation_template, self._template_class)
-        template.texture.texture_normalization = (
-            simulation_template_pb2.Texture.TEXTURE_NORMALIZATION_UNSPECIFIED
-        )
+        template.ClearField("texture")
         return self
 
     def set_texture_normalization_none(self) -> BaseSimulation:
-        """Disable texture normalization."""
+        """Use both the image texture and the texture mapping optical properties."""
         template = getattr(self._simulation_template, self._template_class)
         template.texture.texture_normalization = (
             simulation_template_pb2.Texture.TEXTURE_NORMALIZATION_NONE


### PR DESCRIPTION
## Description
core layer - Simulation feature
Correct docstring and naming for set_texture_xxx methods

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
