### PR TITLE
fix: core - OptProp - various fixes

### DIFF
--- a/doc/changelog.d/1104.fixed.md
+++ b/doc/changelog.d/1104.fixed.md
@@ -1,0 +1,1 @@
+Core - OptProp - various fixes

--- a/src/ansys/speos/core/generic/parameters.py
+++ b/src/ansys/speos/core/generic/parameters.py
@@ -1370,8 +1370,8 @@ class SopTypes(str, Enum):
 class SopMirrorParameters:
     """SOP Mirror Parameters Dataclass."""
 
-    reflectance = 100
-    """Rreflectance of a perfect mirror."""
+    reflectance: float = 100
+    """Reflectance of a perfect mirror."""
 
 
 @dataclass

--- a/src/ansys/speos/core/generic/parameters.py
+++ b/src/ansys/speos/core/generic/parameters.py
@@ -1494,14 +1494,12 @@ class ImageTextureParameters:
     """Whether the image texture repeats along the U direction."""
     repeat_v: bool = True
     """Whether the image texture repeats along the V direction."""
-    mapping: [
-        Union[
-            UVMappingPlanarParameters,
-            UVMappingCubicParameters,
-            UVMappingSphericalParameters,
-            UVMappingCylindricalParameters,
-            UVMappingByData,
-        ]
+    mapping: Union[
+        UVMappingPlanarParameters,
+        UVMappingCubicParameters,
+        UVMappingSphericalParameters,
+        UVMappingCylindricalParameters,
+        UVMappingByData,
     ] = field(default_factory=UVMappingPlanarParameters)
     """Mapping settings applied to the image texture."""
 

--- a/src/ansys/speos/core/opt_prop.py
+++ b/src/ansys/speos/core/opt_prop.py
@@ -153,6 +153,12 @@ class BaseSop:
             self.sop_template_link.delete()
             self.sop_template_link = None
 
+    def _clear_sop_template(self):
+        """Drop the local SOP template, for materials whose SOP is carried elsewhere."""
+        self._sop_template = None
+        self._mirror = None
+        self._library = None
+
     def _fill_sop_template(self, speos_client, sop_guid: str):
         """Populate the local SOP template from a server-side SOP template.
 
@@ -265,8 +271,7 @@ class BaseSop:
         Optional[ansys.speos.core.opt_prop.BaseSop.SopMirror]
             Mirror helper when the active SOP field is ``mirror``, otherwise ``None``.
         """
-        if self._sop_template is not None:
-            return self._mirror
+        return self._mirror
 
     def set_surface_mirror(self) -> BaseSop.SopMirror:
         """Define SOP as a perfect specular surface.
@@ -277,11 +282,8 @@ class BaseSop:
             Returns mirror helper for chaining.
         """
         self._library = None
-        if self._sop_template.HasField("mirror"):
-            self._library = None
-            self._mirror = self.SopMirror(self, stable_ctr=True)
-        else:
-            self._mirror = self.SopMirror(self, stable_ctr=True)
+        self._mirror = self.SopMirror(self, stable_ctr=True)
+        if not self._sop_template.HasField("mirror"):
             self._mirror.reflectance = SopMirrorParameters().reflectance
         return self._mirror
 
@@ -356,7 +358,6 @@ class BaseSop:
             Returns library helper for chaining.
         """
         self._mirror = None
-        self._sop_template.library.SetInParent()
         self._library = self.SopLibrary(self, stable_ctr=True)
         return self._library
 
@@ -370,8 +371,7 @@ class BaseSop:
             Library helper containing ``sop_file_uri`` when SOP is of library
             type, otherwise ``None``.
         """
-        if self._sop_template is not None and self._sop_template.HasField("library"):
-            return self._library
+        return self._library
 
 
 class BaseVop:
@@ -678,8 +678,7 @@ class BaseVop:
             Optic helper containing index, absorption, and constringence when
             VOP is of optic type, otherwise ``None``.
         """
-        if self._vop_template is not None and self._vop_template.HasField("optic"):
-            return self._vop_optic
+        return self._vop_optic
 
     @property
     def vop_library(self) -> Optional[BaseVop.VopLibrary]:
@@ -691,8 +690,7 @@ class BaseVop:
             Library helper containing ``material_file_uri`` when VOP is of
             library type, otherwise ``None``.
         """
-        if self._vop_template is not None and self._vop_template.HasField("library"):
-            return self._vop_library
+        return self._vop_library
 
     def set_volume_none(self) -> "OptProp":
         """Remove any VOP template (no volume optical property).
@@ -703,6 +701,8 @@ class BaseVop:
             Returns self (as the OptProp that owns this VOP helper).
         """
         self._vop_template = None
+        self._vop_optic = None
+        self._vop_library = None
         return self
 
     def set_volume_opaque(self) -> "OptProp":
@@ -716,6 +716,8 @@ class BaseVop:
         if self._vop_template is None:
             self._vop_template = self._new_vop_template()
         self._vop_template.opaque.SetInParent()
+        self._vop_optic = None
+        self._vop_library = None
         return self
 
     def set_volume_optic(
@@ -736,6 +738,7 @@ class BaseVop:
         else:
             self._vop_template.optic.SetInParent()
             self._vop_optic = self.VopOptic(self, VopOpticParameters(), stable_ctr=True)
+        self._vop_library = None
         return self._vop_optic
 
     def set_volume_library(self) -> BaseVop.VopLibrary:
@@ -750,6 +753,7 @@ class BaseVop:
             self._vop_template = self._new_vop_template()
         self._vop_template.library.SetInParent()
         self._vop_library = self.VopLibrary(self, stable_ctr=True)
+        self._vop_optic = None
         return self._vop_library
 
     # Deactivated due to a bug on SpeosRPC server side
@@ -2047,7 +2051,7 @@ class OptProp(BaseVop, BaseSop):
         for layer in value:
             if not isinstance(layer, TextureLayer):
                 raise ValueError("not a texture")
-        self._sop_template = None
+        self._clear_sop_template()
         self._texture = value
 
     @property
@@ -2121,8 +2125,9 @@ class OptProp(BaseVop, BaseSop):
         """
         if self._texture is None:
             self._texture = []
-            if self._sop_template is not None:
-                self._sop_template = None
+            # As we are adding first layer, we need to clear the SOP template.
+            # It is either sop template or texture layers
+            self._clear_sop_template()
         new_layer = TextureLayer(
             opt_prop=self,
             name=name,
@@ -2320,8 +2325,6 @@ class OptProp(BaseVop, BaseSop):
 
         # Save or Update the sop template (depending on if it was already saved before)
         if self.texture:
-            if self._sop_template is not None:
-                self._sop_template = None
             self._material_instance.texture.ClearField("layers")
             layers = []
             for i, layer in enumerate(self.texture):
@@ -2460,5 +2463,5 @@ class OptProp(BaseVop, BaseSop):
         elif len(mat_inst.sop_guids) > 0:
             self.sop_template_link = self._project.client[mat_inst.sop_guids[0]]
         else:  # Specific case for ambient material
-            self._sop_template = None
+            self._clear_sop_template()
         self.reset()

--- a/src/ansys/speos/core/opt_prop.py
+++ b/src/ansys/speos/core/opt_prop.py
@@ -265,7 +265,8 @@ class BaseSop:
         Optional[ansys.speos.core.opt_prop.BaseSop.SopMirror]
             Mirror helper when the active SOP field is ``mirror``, otherwise ``None``.
         """
-        return self._mirror
+        if self._sop_template is not None:
+            return self._mirror
 
     def set_surface_mirror(self) -> BaseSop.SopMirror:
         """Define SOP as a perfect specular surface.
@@ -369,7 +370,7 @@ class BaseSop:
             Library helper containing ``sop_file_uri`` when SOP is of library
             type, otherwise ``None``.
         """
-        if self._sop_template.HasField("library"):
+        if self._sop_template is not None and self._sop_template.HasField("library"):
             return self._library
 
 
@@ -677,7 +678,7 @@ class BaseVop:
             Optic helper containing index, absorption, and constringence when
             VOP is of optic type, otherwise ``None``.
         """
-        if self._vop_template.HasField("optic"):
+        if self._vop_template is not None and self._vop_template.HasField("optic"):
             return self._vop_optic
 
     @property
@@ -690,7 +691,7 @@ class BaseVop:
             Library helper containing ``material_file_uri`` when VOP is of
             library type, otherwise ``None``.
         """
-        if self._vop_template.HasField("library"):
+        if self._vop_template is not None and self._vop_template.HasField("library"):
             return self._vop_library
 
     def set_volume_none(self) -> "OptProp":

--- a/src/ansys/speos/core/opt_prop.py
+++ b/src/ansys/speos/core/opt_prop.py
@@ -1732,19 +1732,22 @@ class TextureLayer(BaseSop):
         """
         if default_parameters.image_texture_parameters:
             self._image_map = TextureLayer.ImageTexture(
-                self._texture_template,
+                self,
                 default_parameters.image_texture_parameters,
                 stable_ctr=True,
             )
         if default_parameters.normal_map_parameters:
             self._normal_map = TextureLayer.NormalMap(
-                self._texture_template,
+                self,
                 default_parameters.normal_map_parameters,
                 stable_ctr=True,
             )
         if default_parameters.anisotropy_map_parameters:
-            if default_parameters.anisotropy_map_parameters:
-                self.normal_map_property = default_parameters.anisotropy_map_parameters
+            self._aniso_map = TextureLayer.AnisotropicMap(
+                self,
+                default_parameters.anisotropy_map_parameters,
+                stable_ctr=True,
+            )
 
     @property
     def image_texture(self) -> ImageTexture:

--- a/src/ansys/speos/core/opt_prop.py
+++ b/src/ansys/speos/core/opt_prop.py
@@ -282,8 +282,11 @@ class BaseSop:
             Returns mirror helper for chaining.
         """
         self._library = None
-        self._mirror = self.SopMirror(self, stable_ctr=True)
-        if not self._sop_template.HasField("mirror"):
+
+        if self._sop_template.HasField("mirror"):
+            self._mirror = self.SopMirror(self, stable_ctr=True)
+        else:
+            self._mirror = self.SopMirror(self, stable_ctr=True)
             self._mirror.reflectance = SopMirrorParameters().reflectance
         return self._mirror
 
@@ -751,7 +754,6 @@ class BaseVop:
         """
         if self._vop_template is None:
             self._vop_template = self._new_vop_template()
-        self._vop_template.library.SetInParent()
         self._vop_library = self.VopLibrary(self, stable_ctr=True)
         self._vop_optic = None
         return self._vop_library

--- a/src/ansys/speos/core/opt_prop.py
+++ b/src/ansys/speos/core/opt_prop.py
@@ -433,6 +433,8 @@ class BaseVop:
                     "what you're doing."
                 )
             self._parent = parent
+            self._parent._vop_template.optic.SetInParent()
+
             if default_parameters:
                 self._fill_parameters(default_parameters)
 
@@ -760,7 +762,6 @@ class BaseVop:
         elif self._vop_template.HasField("optic"):
             self._vop_optic = self.VopOptic(self, None, stable_ctr=True)
         else:
-            self._vop_template.optic.SetInParent()
             self._vop_optic = self.VopOptic(self, VopOpticParameters(), stable_ctr=True)
         self._vop_library = None
         return self._vop_optic

--- a/src/ansys/speos/core/opt_prop.py
+++ b/src/ansys/speos/core/opt_prop.py
@@ -798,10 +798,12 @@ class TextureLayer(BaseSop):
             self,
             mapping,
             default_parameters: Optional[
-                UVMappingCubicParameters,
-                UVMappingPlanarParameters,
-                UVMappingSphericalParameters,
-                UVMappingCylindricalParameters,
+                Union[
+                    UVMappingCubicParameters,
+                    UVMappingPlanarParameters,
+                    UVMappingSphericalParameters,
+                    UVMappingCylindricalParameters,
+                ]
             ] = None,
         ):
             """Initialize a texture mapping operator wrapper.
@@ -824,10 +826,12 @@ class TextureLayer(BaseSop):
         def _fill_parameters(
             self,
             default_parameters: Optional[
-                UVMappingPlanarParameters,
-                UVMappingSphericalParameters,
-                UVMappingCylindricalParameters,
-                UVMappingCubicParameters,
+                Union[
+                    UVMappingPlanarParameters,
+                    UVMappingSphericalParameters,
+                    UVMappingCylindricalParameters,
+                    UVMappingCubicParameters,
+                ]
             ] = None,
         ):
             """Fill mapping operator parameters from default parameters.
@@ -1608,10 +1612,12 @@ class TextureLayer(BaseSop):
             self,
             parent: TextureLayer,
             default_parameters: Optional[
-                UVMappingPlanarParameters,
-                UVMappingSphericalParameters,
-                UVMappingCylindricalParameters,
-                UVMappingCubicParameters,
+                Union[
+                    UVMappingPlanarParameters,
+                    UVMappingSphericalParameters,
+                    UVMappingCylindricalParameters,
+                    UVMappingCubicParameters,
+                ]
             ] = None,
             stable_ctr=False,
         ):
@@ -1641,10 +1647,12 @@ class TextureLayer(BaseSop):
         def _fill_parameters(
             self,
             default_parameters: Optional[
-                UVMappingPlanarParameters,
-                UVMappingSphericalParameters,
-                UVMappingCylindricalParameters,
-                UVMappingCubicParameters,
+                Union[
+                    UVMappingPlanarParameters,
+                    UVMappingSphericalParameters,
+                    UVMappingCylindricalParameters,
+                    UVMappingCubicParameters,
+                ]
             ] = None,
         ):
             """Fill anisotropy map parameters from default parameters.

--- a/src/ansys/speos/core/opt_prop.py
+++ b/src/ansys/speos/core/opt_prop.py
@@ -201,7 +201,7 @@ class BaseSop:
         """
         if isinstance(sop_parameters, SopMirrorParameters):
             self.set_surface_mirror()
-            self.sop_mirror.reflectance = sop_parameters.reflectance
+            self.sop_mirror._fill_parameters(sop_parameters)
         elif sop_parameters == SopTypes.optical_polished:
             self.set_surface_opticalpolished()
         elif isinstance(sop_parameters, SopLibraryParameters):
@@ -212,13 +212,20 @@ class BaseSop:
     class SopMirror:
         """Mirror SOP parameters."""
 
-        def __init__(self, parent: BaseSop, stable_ctr=False):
+        def __init__(
+            self,
+            parent: BaseSop,
+            default_parameters: Optional[SopMirrorParameters] = None,
+            stable_ctr=False,
+        ):
             """Create a mirror helper bound to a parent SOP.
 
             Parameters
             ----------
             parent : ansys.speos.core.opt_prop.BaseSop
                 Base SOP wrapper that owns the mirror protobuf field.
+            default_parameters : Optional[ansys.speos.core.generic.parameters.SopMirrorParameters]
+                Default mirror parameters to apply during initialization.
             stable_ctr : bool, optional
                 Internal guard to prevent unintended direct instantiation.
             """
@@ -230,6 +237,19 @@ class BaseSop:
                 )
             self._parent = parent
             self._parent._sop_template.mirror.SetInParent()
+
+            if default_parameters:
+                self._fill_parameters(default_parameters)
+
+        def _fill_parameters(self, default_parameters: SopMirrorParameters):
+            """Fill mirror parameters from default parameters.
+
+            Parameters
+            ----------
+            default_parameters : ansys.speos.core.generic.parameters.SopMirrorParameters
+                Default mirror parameters to apply.
+            """
+            self.reflectance = default_parameters.reflectance
 
         @property
         def reflectance(self) -> float:
@@ -284,10 +304,11 @@ class BaseSop:
         self._library = None
 
         if self._sop_template.HasField("mirror"):
-            self._mirror = self.SopMirror(self, stable_ctr=True)
+            self._mirror = self.SopMirror(self, default_parameters=None, stable_ctr=True)
         else:
-            self._mirror = self.SopMirror(self, stable_ctr=True)
-            self._mirror.reflectance = SopMirrorParameters().reflectance
+            self._mirror = self.SopMirror(
+                self, default_parameters=SopMirrorParameters(), stable_ctr=True
+            )
         return self._mirror
 
     def set_surface_opticalpolished(self) -> BaseSop:

--- a/tests/core/test_opt_prop.py
+++ b/tests/core/test_opt_prop.py
@@ -35,6 +35,7 @@ from ansys.speos.core.generic.parameters import (
     NormalMapTypes,
     OptPropParameters,
     SopLibraryParameters,
+    SopMirrorParameters,
     SopTypes,
     TextureLayerParameters,
     TextureTypes,
@@ -499,6 +500,25 @@ def test_opt_prop_default_parameters_and_local_helpers(speos: Speos, capsys):
 
     assert op_local.get("definitely_missing_key") is None
     assert "Used key: definitely_missing_key not found" in capsys.readouterr().out
+
+
+def test_sop_mirror_parameters_reflectance_is_a_field():
+    """Check that the mirror reflectance can be customized through the dataclass."""
+    assert SopMirrorParameters().reflectance == 100
+    assert SopMirrorParameters(reflectance=42).reflectance == 42
+
+
+def test_create_optical_property_with_custom_reflectance(speos: Speos):
+    """Check that a custom mirror reflectance is applied to the SOP template."""
+    p = Project(speos=speos)
+
+    op = p.create_optical_property(
+        name="Mirror.CustomReflectance",
+        parameters=OptPropParameters(sop_parameters=SopMirrorParameters(reflectance=42)),
+    )
+
+    assert op.sop_mirror.reflectance == 42
+    assert op._sop_template.mirror.reflectance == 42
 
 
 @pytest.mark.supported_speos_versions(min=252)

--- a/tests/core/test_opt_prop.py
+++ b/tests/core/test_opt_prop.py
@@ -1558,10 +1558,9 @@ def test_texture_layer_parameter_fill_branch_paths(speos: Speos):
         ),
     )
 
-    # Current implementation passes an internal protobuf layer into map helpers.
-    # Keep this behavior covered until constructor wiring is refactored.
-    with pytest.raises(AttributeError, match="_sop_template"):
-        TextureLayer(op, "Layer.Coverage", default_parameters=params)
+    layer = TextureLayer(op, "Layer.Coverage", default_parameters=params)
+    assert layer.image_texture is not None
+    assert layer.normal_map is not None
 
     layer = TextureLayer(op, "Layer.Coverage")
     assert layer.set_image_texture() is not None
@@ -1570,3 +1569,49 @@ def test_texture_layer_parameter_fill_branch_paths(speos: Speos):
     # Hit branch where image_properties already exists.
     layer._image_map = None
     assert layer.set_image_texture() is not None
+
+
+@pytest.mark.supported_speos_versions(min=252)
+def test_texture_layer_parameters_build_all_maps(speos: Speos):
+    """Check that TextureLayerParameters builds the image, normal and anisotropy maps."""
+    p = Project(speos=speos)
+    op = p.create_optical_property(name="Texture.Parameters")
+
+    params = TextureLayerParameters(
+        image_texture_parameters=ImageTextureParameters(
+            file_path=Path("image_params.png"),
+            repeat_u=False,
+            mapping=UVMappingPlanarParameters(rotation=20),
+        ),
+        normal_map_parameters=NormalMapParameters(
+            file_path=Path("normal_params.png"),
+            normal_map_type=NormalMapTypes.from_image,
+            roughness=0.5,
+            mapping=UVMappingCubicParameters(rotation=30),
+        ),
+        anisotropy_map_parameters=UVMappingCylindricalParameters(rotation=40),
+    )
+
+    layer = TextureLayer(op, "Layer.Parameters", default_parameters=params)
+
+    assert layer.image_texture is not None
+    assert layer.image_texture.image_file_uri == "image_params.png"
+    assert layer.image_texture.repeat_u is False
+    assert layer.image_texture.uv_mapping.rotation == 20
+
+    assert layer.normal_map is not None
+    assert layer.normal_map.normal_map_file_uri == "normal_params.png"
+    assert layer.normal_map.uv_mapping.rotation == 30
+
+    assert layer.anisotropic_map is not None
+    assert layer.anisotropic_map.uv_mapping.rotation == 40
+
+    # The maps must be bound to the texture layer, not to its protobuf message.
+    assert layer.image_texture._parent is layer
+    assert layer.normal_map._parent is layer
+    assert layer.anisotropic_map._parent is layer
+
+    # No stray attribute created instead of the anisotropy map.
+    assert not hasattr(layer, "normal_map_property")
+
+    op.delete()

--- a/tests/core/test_opt_prop.py
+++ b/tests/core/test_opt_prop.py
@@ -1635,3 +1635,34 @@ def test_texture_layer_parameters_build_all_maps(speos: Speos):
     assert not hasattr(layer, "normal_map_property")
 
     op.delete()
+
+
+def test_helper_properties_without_template(speos: Speos):
+    """Check that SOP/VOP helper properties return None when the template is not set."""
+    p = Project(speos=speos)
+    op = p.create_optical_property(name="NoTemplate")
+
+    # A brand new optical property has no VOP template at all.
+    assert op._vop_template is None
+    assert op.vop_optic is None  # this should return None, not crash
+    assert op.vop_library is None  # this should return None, not crash
+
+    # Going back to "no volume property" must not break the accessors either.
+    op.set_volume_optic()
+    assert op.vop_optic is not None
+    assert op.vop_library is None  # still None because we didn't set a library
+    op.set_volume_none()
+    assert op.vop_optic is None  # both back to None
+    assert op.vop_library is None  # both back to None
+
+    op.set_volume_library()
+    assert op.vop_library is not None
+    assert op.vop_optic is None  # still None because we didn't set an optic
+    op.set_volume_none()
+    assert op.vop_optic is None  # both back to None
+    assert op.vop_library is None  # both back to None
+
+    # A textured material has no SOP template of its own.
+    op._sop_template = None
+    assert op.sop_library is None
+    assert op.sop_mirror is None

--- a/tests/core/test_opt_prop.py
+++ b/tests/core/test_opt_prop.py
@@ -1637,10 +1637,10 @@ def test_texture_layer_parameters_build_all_maps(speos: Speos):
     op.delete()
 
 
-def test_helper_properties_without_template(speos: Speos):
-    """Check that SOP/VOP helper properties return None when the template is not set."""
+def test_vop_helper_properties(speos: Speos):
+    """Check VOP helper properties."""
     p = Project(speos=speos)
-    op = p.create_optical_property(name="NoTemplate")
+    op = p.create_optical_property(name="TestVOP")
 
     # A brand new optical property has no VOP template at all.
     assert op._vop_template is None
@@ -1648,19 +1648,30 @@ def test_helper_properties_without_template(speos: Speos):
     assert op.vop_library is None  # this should return None, not crash
 
     # Going back to "no volume property" must not break the accessors either.
-    op.set_volume_optic()
-    assert op.vop_optic is not None
+    optic = op.set_volume_optic()
+    assert op._vop_template.HasField("optic")
+    assert op.vop_optic is optic
     assert op.vop_library is None  # still None because we didn't set a library
     op.set_volume_none()
+    assert op._vop_template is None
     assert op.vop_optic is None  # both back to None
     assert op.vop_library is None  # both back to None
 
-    op.set_volume_library()
-    assert op.vop_library is not None
+    # Library then Opaque
+    lib = op.set_volume_library()
+    assert op._vop_template.HasField("library")
+    assert op.vop_library is lib
     assert op.vop_optic is None  # still None because we didn't set an optic
-    op.set_volume_none()
+    op.set_volume_opaque()
+    assert op._vop_template.HasField("opaque")
     assert op.vop_optic is None  # both back to None
     assert op.vop_library is None  # both back to None
+
+    # Then back to None again
+    op.set_volume_none()
+    assert op._vop_template is None
+    assert op.vop_optic is None  # both still are None
+    assert op.vop_library is None  # both still are None
 
 
 @pytest.mark.supported_speos_versions(min=252)
@@ -1678,36 +1689,27 @@ def test_helper_properties_on_textured_material(speos: Speos):
     assert op.sop_library is None
 
 
-def test_helper_properties_follow_active_field(speos: Speos):
-    """Check that SOP/VOP helper properties always reflect the active protobuf field."""
+def test_sop_helper_properties(speos: Speos):
+    """Check SOP helper properties."""
     p = Project(speos=speos)
-    op = p.create_optical_property(name="ActiveField")
+    op = p.create_optical_property(name="TestSOP")
 
-    # Switching between VOP types must never expose a helper of the previous type.
-    optic = op.set_volume_optic()
-    assert op.vop_optic is optic
-    assert op.vop_library is None
+    assert op._sop_template is not None
 
-    library = op.set_volume_library()
-    assert op.vop_library is library
-    assert op.vop_optic is None
-
-    op.set_volume_opaque()
-    assert op.vop_optic is None
-    assert op.vop_library is None
-
-    assert op.set_volume_optic() is not None
-    assert op.vop_library is None
-
-    # Same expectation on the SOP side.
+    # Go for mirror
     mirror = op.set_surface_mirror()
+    assert op._sop_template.HasField("mirror")
     assert op.sop_mirror is mirror
     assert op.sop_library is None
 
-    sop_library = op.set_surface_library()
-    assert op.sop_library is sop_library
-    assert op.sop_mirror is None
-
+    # Then optical polished
     op.set_surface_opticalpolished()
+    assert op._sop_template.HasField("optical_polished")
     assert op.sop_mirror is None
     assert op.sop_library is None
+
+    # Then library
+    lib = op.set_surface_library()
+    assert op._sop_template.HasField("library")
+    assert op.sop_library is lib
+    assert op.sop_mirror is None

--- a/tests/core/test_opt_prop.py
+++ b/tests/core/test_opt_prop.py
@@ -1662,7 +1662,52 @@ def test_helper_properties_without_template(speos: Speos):
     assert op.vop_optic is None  # both back to None
     assert op.vop_library is None  # both back to None
 
-    # A textured material has no SOP template of its own.
-    op._sop_template = None
-    assert op.sop_library is None
+
+@pytest.mark.supported_speos_versions(min=252)
+def test_helper_properties_on_textured_material(speos: Speos):
+    """Check that SOP helpers are dropped when the SOP is carried by texture layers."""
+    p = Project(speos=speos)
+    op = p.create_optical_property(name="TexturedNoSop")
+
+    assert op.sop_mirror is not None
+
+    # A textured material has no SOP template of its own: each layer owns one.
+    op.create_texture_layer()
+    assert op._sop_template is None
     assert op.sop_mirror is None
+    assert op.sop_library is None
+
+
+def test_helper_properties_follow_active_field(speos: Speos):
+    """Check that SOP/VOP helper properties always reflect the active protobuf field."""
+    p = Project(speos=speos)
+    op = p.create_optical_property(name="ActiveField")
+
+    # Switching between VOP types must never expose a helper of the previous type.
+    optic = op.set_volume_optic()
+    assert op.vop_optic is optic
+    assert op.vop_library is None
+
+    library = op.set_volume_library()
+    assert op.vop_library is library
+    assert op.vop_optic is None
+
+    op.set_volume_opaque()
+    assert op.vop_optic is None
+    assert op.vop_library is None
+
+    assert op.set_volume_optic() is not None
+    assert op.vop_library is None
+
+    # Same expectation on the SOP side.
+    mirror = op.set_surface_mirror()
+    assert op.sop_mirror is mirror
+    assert op.sop_library is None
+
+    sop_library = op.set_surface_library()
+    assert op.sop_library is sop_library
+    assert op.sop_mirror is None
+
+    op.set_surface_opticalpolished()
+    assert op.sop_mirror is None
+    assert op.sop_library is None


### PR DESCRIPTION
## Description
core layer
OptProp feature
Several fixes are performed here:
- Fix TextureLayer _fill_parameters method
- Fix reflectance field in dataclass SopMirrorParameters
- Missing Union in typing
- Accessors:
  - vop_optic / vop_library / sop_library crash when the template is None
  - Make accessor style consistent - avoid retest HasField
- SopMirror uses now default_properties, like VopOptic. Harmonization

## Issue linked

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have assigned this PR to myself.
- [ ] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
