### PR TITLE
fix: core - optprop - work on _to_dict() method (texture missing)

### DIFF
--- a/doc/changelog.d/1107.fixed.md
+++ b/doc/changelog.d/1107.fixed.md
@@ -1,0 +1,1 @@
+Core - optprop - work on _to_dict() method (texure missing)

--- a/doc/changelog.d/1107.fixed.md
+++ b/doc/changelog.d/1107.fixed.md
@@ -1,1 +1,1 @@
-Core - optprop - work on _to_dict() method (texure missing)
+Core - optprop - work on _to_dict() method (texture missing)

--- a/doc/changelog.d/1107.fixed.md
+++ b/doc/changelog.d/1107.fixed.md
@@ -1,1 +1,1 @@
-Core - optprop - work on _to_dict() method (texture missing)
+Core - optprop - work on _to_dict() method (texure missing)

--- a/examples/core/opt-prop.py
+++ b/examples/core/opt-prop.py
@@ -165,7 +165,7 @@ print(op1)
 # +
 print("op1 name: {}".format(op1.get(key="name")))
 print("geometries linked to op1: {}".format(op1.get(key="geo_paths")))
-print("op1 surface optical properties info: {}".format(op1.get(key="sops")))
+print("op1 surface optical properties info: {}".format(op1.get(key="sop")))
 print("op1 volume optical property info: {}".format(op1.get(key="vop")))
 # user can use get with vop type as key word to check volume property type
 print(
@@ -178,7 +178,7 @@ print(op2)
 print("op2 name: {}".format(op2.get(key="name")))
 print(
     "op2 {} optical polished type surface property".format(
-        ("is" if "optical_polished" in op2.get(key="sops")[0] else "is not")
+        ("is" if "optical_polished" in op2.get(key="sop") else "is not")
     )
 )
 # an alternative way to check the type of optical property
@@ -190,7 +190,7 @@ print(
 
 print(op3)
 print("op3 name: {}".format(op3.get(key="name")))
-print("op3 has reflectance value of {}".format(op3.get(key="sops")[0]["mirror"]["reflectance"]))
+print("op3 has reflectance value of {}".format(op3.get(key="sop")["mirror"]["reflectance"]))
 # -
 
 # ### Project Information
@@ -206,12 +206,12 @@ print(p)
 # If you don't, you will still only watch what is committed on the server.
 
 
-print("op1 surface type before update: {}".format(op1.get(key="sops")[0]))
+print("op1 surface type before update: {}".format(op1.get(key="sop")))
 op1.set_volume_optic()
 op1.set_surface_opticalpolished()
 op1.commit()
 print(op1)
-print("op1 surface type after update: {}".format(op1.get(key="sops")[0]))
+print("op1 surface type after update: {}".format(op1.get(key="sop")))
 
 
 # ## Reset

--- a/src/ansys/speos/core/opt_prop.py
+++ b/src/ansys/speos/core/opt_prop.py
@@ -2233,6 +2233,60 @@ class OptProp(BaseVop, BaseSop):
                 message=self._material_instance,
             )
 
+            # VopTemplate need to be added to the dict even if no commit was performed yet.
+            if (
+                "vop" not in out_dict.keys()
+                and self.vop_template_link is None
+                and self._vop_template is not None
+            ):
+                out_dict["vop"] = proto_message_utils._replace_guids(
+                    speos_client=self._project.client,
+                    message=self._vop_template,
+                )
+
+            # SopTemplate need to be added to the dict even if no commit was performed yet.
+            # Need to make distinction about key name depending on server capability
+            # regarding textures
+            if self._project.client.scenes()._is_texture_available:
+                if (
+                    "sop" not in out_dict.keys()
+                    and self.sop_template_link is None
+                    and self._sop_template is not None
+                ):
+                    out_dict["sop"] = proto_message_utils._replace_guids(
+                        speos_client=self._project.client,
+                        message=self._sop_template,
+                    )
+            else:
+                if (
+                    "sops" not in out_dict.keys()
+                    and self.sop_template_link is None
+                    and self._sop_template is not None
+                ):
+                    out_dict["sops"] = [
+                        proto_message_utils._replace_guids(
+                            speos_client=self._project.client,
+                            message=self._sop_template,
+                        )
+                    ]
+
+            # Texture need to be added to the dict even if no commit was performed yet.
+            if (
+                "texture" in out_dict.keys()
+                and len(out_dict["texture"]["layers"]) == 0
+                and self._texture is not None
+            ):
+                for layer in self._texture:
+                    layer_dict = proto_message_utils._replace_guids(
+                        speos_client=self._project.client,
+                        message=layer._texture_template,
+                    )
+                    layer_dict["sop"] = proto_message_utils._replace_guids(
+                        speos_client=self._project.client,
+                        message=layer._sop_template,
+                    )
+                    out_dict["texture"]["layers"].append(layer_dict)
+
         proto_message_utils._replace_properties(json_dict=out_dict)
 
         return out_dict

--- a/src/ansys/speos/core/opt_prop.py
+++ b/src/ansys/speos/core/opt_prop.py
@@ -2211,7 +2211,7 @@ class OptProp(BaseVop, BaseSop):
         """
         out_dict = {}
 
-        # MaterialInstance (= vop guid + sop guids + geometries)
+        # MaterialInstance (= vop guid + sop guid/texture + geometries)
         if self._project.scene_link and self._unique_id is not None:
             scene_data = self._project.scene_link.get()
             mat_inst = next(
@@ -2232,38 +2232,6 @@ class OptProp(BaseVop, BaseSop):
                 speos_client=self._project.client,
                 message=self._material_instance,
             )
-
-        if "vop" not in out_dict.keys():
-            # VopTemplate
-            if self.vop_template_link is None:
-                if self._vop_template is not None:
-                    out_dict["vop"] = proto_message_utils._replace_guids(
-                        speos_client=self._project.client,
-                        message=self._vop_template,
-                    )
-            else:
-                out_dict["vop"] = proto_message_utils._replace_guids(
-                    speos_client=self._project.client,
-                    message=self.vop_template_link.get(),
-                )
-
-        if "sops" not in out_dict.keys():
-            # SopTemplate
-            if self.sop_template_link is None:
-                if self._sop_template is not None:
-                    out_dict["sops"] = [
-                        proto_message_utils._replace_guids(
-                            speos_client=self._project.client,
-                            message=self._sop_template,
-                        )
-                    ]
-            else:
-                out_dict["sops"] = [
-                    proto_message_utils._replace_guids(
-                        speos_client=self._project.client,
-                        message=self.sop_template_link.get(),
-                    )
-                ]
 
         proto_message_utils._replace_properties(json_dict=out_dict)
 

--- a/tests/core/test_opt_prop.py
+++ b/tests/core/test_opt_prop.py
@@ -524,6 +524,84 @@ def test_create_optical_property_with_custom_reflectance(speos: Speos):
 
 
 @pytest.mark.supported_speos_versions(min=252)
+def test_opt_prop_to_dict(speos: Speos):
+    """Check _to_dict output for SOP, VOP, and texture combinations."""
+    p = Project(speos=speos)
+    scene_db = speos.client.scenes()
+
+    # VOP only
+    vop_only = p.create_optical_property(name="ToDict.VopOnly")
+    vop_only.set_volume_opaque()
+    vop_only._clear_sop_template()
+    vop_only.commit()
+    vop_only_dict = vop_only._to_dict()
+    assert "vop" in vop_only_dict
+    assert "opaque" in vop_only_dict["vop"]
+    assert "sops" not in vop_only_dict
+    assert "sop" not in vop_only_dict
+
+    # SOP only
+    sop_only = p.create_optical_property(name="ToDict.SopOnly")
+    sop_only.set_surface_opticalpolished()
+    # No commit to test that _to_dict works even if not committed
+    sop_only_dict = sop_only._to_dict()
+    if scene_db._is_texture_available:
+        assert "sop" in sop_only_dict
+        assert "optical_polished" in sop_only_dict["sop"]
+    else:
+        assert "sops" in sop_only_dict
+        assert "optical_polished" in sop_only_dict["sops"][0]
+    assert "vop" not in sop_only_dict
+
+    # VOP and SOP
+    vop_and_sop = p.create_optical_property(name="ToDict.VopAndSop")
+    vop_and_sop.set_volume_optic()
+    vop_and_sop.set_surface_mirror().reflectance = 80
+    vop_and_sop.commit()
+    vop_and_sop_dict = vop_and_sop._to_dict()
+    assert "vop" in vop_and_sop_dict
+    assert "optic" in vop_and_sop_dict["vop"]
+    if scene_db._is_texture_available:
+        assert "sop" in vop_and_sop_dict
+        assert "mirror" in vop_and_sop_dict["sop"]
+        assert vop_and_sop_dict["sop"]["mirror"]["reflectance"] == 80
+    else:
+        assert "sops" in vop_and_sop_dict
+        assert "mirror" in vop_and_sop_dict["sops"][0]
+        assert vop_and_sop_dict["sops"][0]["mirror"]["reflectance"] == 80
+
+    # Textures
+    if scene_db._is_texture_available:
+        # No VOP, texture one layer
+        texture_one_layer = p.create_optical_property(name="ToDict.TextureOneLayer")
+        texture_one_layer.create_texture_layer()
+        texture_one_layer.commit()
+        texture_one_layer_dict = texture_one_layer._to_dict()
+        assert "vop" not in texture_one_layer_dict
+        assert "texture" in texture_one_layer_dict
+        assert len(texture_one_layer_dict["texture"]["layers"]) == 1
+        assert "sop" in texture_one_layer_dict["texture"]["layers"][0]
+        assert "mirror" in texture_one_layer_dict["texture"]["layers"][0]["sop"]
+        assert texture_one_layer_dict["texture"]["layers"][0]["sop"]["mirror"]["reflectance"] == 100
+
+        # VOP, texture two layers
+        texture_with_vop = p.create_optical_property(name="ToDict.TextureWithVop")
+        texture_with_vop.set_volume_opaque()
+        texture_with_vop.create_texture_layer()
+        texture_with_vop.create_texture_layer().set_surface_opticalpolished()
+        texture_with_vop.commit()
+        texture_with_vop_dict = texture_with_vop._to_dict()
+        assert "vop" in texture_with_vop_dict
+        assert "opaque" in texture_with_vop_dict["vop"]
+        assert "texture" in texture_with_vop_dict
+        assert len(texture_with_vop_dict["texture"]["layers"]) == 2
+        assert "sop" in texture_with_vop_dict["texture"]["layers"][0]
+        assert "mirror" in texture_with_vop_dict["texture"]["layers"][0]["sop"]
+        assert "sop" in texture_with_vop_dict["texture"]["layers"][1]
+        assert "optical_polished" in texture_with_vop_dict["texture"]["layers"][1]["sop"]
+
+
+@pytest.mark.supported_speos_versions(min=252)
 def test_create_texture_property(speos: Speos):
     """Test creation of texture property."""
     p = Project(speos=speos)

--- a/tests/core/test_opt_prop.py
+++ b/tests/core/test_opt_prop.py
@@ -49,7 +49,7 @@ from ansys.speos.core.generic.parameters import (
     VopTypes,
 )
 from ansys.speos.core.kernel import ProtoFace
-from ansys.speos.core.kernel.scene import ProtoScene
+from ansys.speos.core.kernel.scene import ProtoScene, SceneStub
 from ansys.speos.core.kernel.sop_template import ProtoSOPTemplate
 from ansys.speos.core.kernel.vop_template import ProtoVOPTemplate
 from ansys.speos.core.opt_prop import BaseSop, BaseVop, TextureLayer
@@ -343,7 +343,11 @@ def test_get_optical_property(speos: Speos, capsys):
     assert "optic" not in vop_property_info
     assert "library" not in vop_property_info
     # test sops
-    sop_property_info = op1.get(key="sops")[0]
+    sop_property_info = None
+    if speos.client.scenes()._is_texture_available:
+        sop_property_info = op1.get(key="sop")
+    else:
+        sop_property_info = op1.get(key="sops")[0]
     assert "mirror" in sop_property_info
     assert "optical_polished" not in sop_property_info
     assert "library" not in sop_property_info
@@ -368,7 +372,10 @@ def test_get_optical_property(speos: Speos, capsys):
     assert "optic" in vop_property_info
     assert "library" not in vop_property_info
     # test sops
-    sop_property_info = op2.get(key="sops")[0]
+    if speos.client.scenes()._is_texture_available:
+        sop_property_info = op2.get(key="sop")
+    else:
+        sop_property_info = op2.get(key="sops")[0]
     assert "mirror" not in sop_property_info
     assert "optical_polished" in sop_property_info
     assert "library" not in sop_property_info
@@ -386,7 +393,10 @@ def test_get_optical_property(speos: Speos, capsys):
     # test vop
     assert op3.get(key="vop") is None
     # test sops
-    sop_property_info = op3.get(key="sops")[0]
+    if speos.client.scenes()._is_texture_available:
+        sop_property_info = op3.get(key="sop")
+    else:
+        sop_property_info = op3.get(key="sops")[0]
     assert "mirror" not in sop_property_info
     assert "optical_polished" not in sop_property_info
     assert "library" in sop_property_info
@@ -497,7 +507,10 @@ def test_opt_prop_default_parameters_and_local_helpers(speos: Speos, capsys):
     local_dict = op_local._to_dict()
 
     assert "vop" in local_dict
-    assert "sops" in local_dict
+    if speos.client.scenes()._is_texture_available:
+        assert "sop" in local_dict
+    else:
+        assert "sops" in local_dict
     assert "local:" in str(op_local)
 
     assert op_local.get("definitely_missing_key") is None
@@ -523,6 +536,32 @@ def test_create_optical_property_with_custom_reflectance(speos: Speos):
     assert op._sop_template.mirror.reflectance == 42
 
 
+def _assert_vop_opaque_no_sop(vop_only_dict: dict):
+    assert "vop" in vop_only_dict
+    assert "opaque" in vop_only_dict["vop"]
+    assert "sops" not in vop_only_dict
+    assert "sop" not in vop_only_dict
+
+
+def _assert_sop_optical_polished_no_vop(sop_only_dict: dict, scene_db: SceneStub):
+    if scene_db._is_texture_available:
+        assert "sop" in sop_only_dict
+        assert "optical_polished" in sop_only_dict["sop"]
+    else:
+        assert "sops" in sop_only_dict
+        assert "optical_polished" in sop_only_dict["sops"][0]
+    assert "vop" not in sop_only_dict
+
+
+def _assert_texture_no_vop(texture_one_layer_dict: dict):
+    assert "vop" not in texture_one_layer_dict
+    assert "texture" in texture_one_layer_dict
+    assert len(texture_one_layer_dict["texture"]["layers"]) == 1
+    assert "sop" in texture_one_layer_dict["texture"]["layers"][0]
+    assert "mirror" in texture_one_layer_dict["texture"]["layers"][0]["sop"]
+    assert texture_one_layer_dict["texture"]["layers"][0]["sop"]["mirror"]["reflectance"] == 100
+
+
 @pytest.mark.supported_speos_versions(min=252)
 def test_opt_prop_to_dict(speos: Speos):
     """Check _to_dict output for SOP, VOP, and texture combinations."""
@@ -533,25 +572,24 @@ def test_opt_prop_to_dict(speos: Speos):
     vop_only = p.create_optical_property(name="ToDict.VopOnly")
     vop_only.set_volume_opaque()
     vop_only._clear_sop_template()
+    # Before commit
+    vop_only_dict = vop_only._to_dict()
+    _assert_vop_opaque_no_sop(vop_only_dict)
+    # After commit
     vop_only.commit()
     vop_only_dict = vop_only._to_dict()
-    assert "vop" in vop_only_dict
-    assert "opaque" in vop_only_dict["vop"]
-    assert "sops" not in vop_only_dict
-    assert "sop" not in vop_only_dict
+    _assert_vop_opaque_no_sop(vop_only_dict)
 
     # SOP only
     sop_only = p.create_optical_property(name="ToDict.SopOnly")
     sop_only.set_surface_opticalpolished()
-    # No commit to test that _to_dict works even if not committed
+    # Before commit
     sop_only_dict = sop_only._to_dict()
-    if scene_db._is_texture_available:
-        assert "sop" in sop_only_dict
-        assert "optical_polished" in sop_only_dict["sop"]
-    else:
-        assert "sops" in sop_only_dict
-        assert "optical_polished" in sop_only_dict["sops"][0]
-    assert "vop" not in sop_only_dict
+    _assert_sop_optical_polished_no_vop(sop_only_dict, scene_db)
+    # After commit
+    sop_only.commit()
+    sop_only_dict = sop_only._to_dict()
+    _assert_sop_optical_polished_no_vop(sop_only_dict, scene_db)
 
     # VOP and SOP
     vop_and_sop = p.create_optical_property(name="ToDict.VopAndSop")
@@ -575,14 +613,13 @@ def test_opt_prop_to_dict(speos: Speos):
         # No VOP, texture one layer
         texture_one_layer = p.create_optical_property(name="ToDict.TextureOneLayer")
         texture_one_layer.create_texture_layer()
+        # Before commit
+        texture_one_layer_dict = texture_one_layer._to_dict()
+        _assert_texture_no_vop(texture_one_layer_dict)
+        # After commit
         texture_one_layer.commit()
         texture_one_layer_dict = texture_one_layer._to_dict()
-        assert "vop" not in texture_one_layer_dict
-        assert "texture" in texture_one_layer_dict
-        assert len(texture_one_layer_dict["texture"]["layers"]) == 1
-        assert "sop" in texture_one_layer_dict["texture"]["layers"][0]
-        assert "mirror" in texture_one_layer_dict["texture"]["layers"][0]["sop"]
-        assert texture_one_layer_dict["texture"]["layers"][0]["sop"]["mirror"]["reflectance"] == 100
+        _assert_texture_no_vop(texture_one_layer_dict)
 
         # VOP, texture two layers
         texture_with_vop = p.create_optical_property(name="ToDict.TextureWithVop")

--- a/tests/core/test_opt_prop.py
+++ b/tests/core/test_opt_prop.py
@@ -579,6 +579,14 @@ def test_opt_prop_to_dict(speos: Speos):
     vop_only.commit()
     vop_only_dict = vop_only._to_dict()
     _assert_vop_opaque_no_sop(vop_only_dict)
+    # After reset
+    vop_only.reset()
+    vop_only_dict = vop_only._to_dict()
+    _assert_vop_opaque_no_sop(vop_only_dict)
+    # After delete
+    vop_only.delete()
+    vop_only_dict = vop_only._to_dict()
+    _assert_vop_opaque_no_sop(vop_only_dict)
 
     # SOP only
     sop_only = p.create_optical_property(name="ToDict.SopOnly")
@@ -588,6 +596,14 @@ def test_opt_prop_to_dict(speos: Speos):
     _assert_sop_optical_polished_no_vop(sop_only_dict, scene_db)
     # After commit
     sop_only.commit()
+    sop_only_dict = sop_only._to_dict()
+    _assert_sop_optical_polished_no_vop(sop_only_dict, scene_db)
+    # After reset
+    sop_only.reset()
+    sop_only_dict = sop_only._to_dict()
+    _assert_sop_optical_polished_no_vop(sop_only_dict, scene_db)
+    # After delete
+    sop_only.delete()
     sop_only_dict = sop_only._to_dict()
     _assert_sop_optical_polished_no_vop(sop_only_dict, scene_db)
 
@@ -618,6 +634,14 @@ def test_opt_prop_to_dict(speos: Speos):
         _assert_texture_no_vop(texture_one_layer_dict)
         # After commit
         texture_one_layer.commit()
+        texture_one_layer_dict = texture_one_layer._to_dict()
+        _assert_texture_no_vop(texture_one_layer_dict)
+        # After reset
+        texture_one_layer.reset()
+        texture_one_layer_dict = texture_one_layer._to_dict()
+        _assert_texture_no_vop(texture_one_layer_dict)
+        # After delete
+        texture_one_layer.delete()
         texture_one_layer_dict = texture_one_layer._to_dict()
         _assert_texture_no_vop(texture_one_layer_dict)
 


### PR DESCRIPTION
## Description
Core layer
OptProp feature
_to_dict() method
Two fixes:
- The texture is now returned, even if the OptProp is not committed.
- Dict key names is now exactly same (regarding sop/sops) if the OptProp is or is not committed.

## Issue linked

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
