### PR TITLE
fix: core - project - raise error if vbb is not supported by the server

### DIFF
--- a/doc/changelog.d/1109.fixed.md
+++ b/doc/changelog.d/1109.fixed.md
@@ -1,0 +1,1 @@
+Core - project - raise error if vbb is not supported by the server

--- a/src/ansys/speos/core/kernel/scene.py
+++ b/src/ansys/speos/core/kernel/scene.py
@@ -31,6 +31,7 @@ from ansys.api.speos.scene.v2 import (
     scene_pb2_grpc as service,
 )
 
+from ansys.speos.core.generic.version_checker import server_version_checker
 from ansys.speos.core.kernel.crud import CrudItem, CrudStub
 from ansys.speos.core.kernel.proto_message_utils import protobuf_message_to_str
 from ansys.speos.core.kernel.sop_template import ProtoSOPTemplate, SOPTemplateStub
@@ -208,6 +209,12 @@ class SceneStub(CrudStub):
         self._is_texture_available = self._check_if_texture_available(channel=channel)
 
     def _check_if_texture_available(self, channel) -> bool:
+        # The texture feature is available in SPEOS 2025 R1 SP1 and later.
+        # The version checker is only available from 2026 R1, so we check first the version
+        if server_version_checker.is_version_supported(2025, 1, 1):
+            return True
+
+        # If not available, check the presence of the sop_guid field in the scene material instance.
         sop_t_stub = SOPTemplateStub(channel=channel)
         # Create SOPTemplate then scene
         sop_t_link = sop_t_stub.create(

--- a/src/ansys/speos/core/kernel/scene.py
+++ b/src/ansys/speos/core/kernel/scene.py
@@ -209,9 +209,9 @@ class SceneStub(CrudStub):
         self._is_texture_available = self._check_if_texture_available(channel=channel)
 
     def _check_if_texture_available(self, channel) -> bool:
-        # The texture feature is available in SPEOS 2025 R1 SP1 and later.
+        # The texture feature is available in SPEOS 2025 R2 SP1 and later.
         # The version checker is only available from 2026 R1, so we check first the version
-        if server_version_checker.is_version_supported(2025, 1, 1):
+        if server_version_checker.is_version_supported(2025, 2, 1):
             return True
 
         # If not available, check the presence of the sop_guid field in the scene material instance.

--- a/src/ansys/speos/core/project.py
+++ b/src/ansys/speos/core/project.py
@@ -737,7 +737,7 @@ class Project:
                 if not self.client.scenes()._is_texture_available:
                     raise NotImplementedError(
                         "SimulationVirtualBSDF is not supported in the current server version.\
-                            It needs a Speos Version of 25 R1 SP1 or higher."
+                            It needs a Speos Version of 25 R2 SP1 or higher."
                     )
 
                 if parameters is None:

--- a/src/ansys/speos/core/project.py
+++ b/src/ansys/speos/core/project.py
@@ -731,6 +731,15 @@ class Project:
                     default_parameters=parameters,
                 )
             case "SimulationVirtualBSDF":
+                # Here we are using the fact that VBB simu appeared in same release as
+                # texture feature.
+                # Because at that time it was not possible to check the version of the server.
+                if not self.client.scenes()._is_texture_available:
+                    raise NotImplementedError(
+                        "SimulationVirtualBSDF is not supported in the current server version.\
+                            It needs a Speos Version of 25 R1 SP1 or higher."
+                    )
+
                 if parameters is None:
                     parameters = VirtualBSDFSimulationParameters()
                 elif not isinstance(parameters, VirtualBSDFSimulationParameters):

--- a/tests/core/test_simulation.py
+++ b/tests/core/test_simulation.py
@@ -562,6 +562,14 @@ def test_create_interactive(speos: Speos):
     sim1.delete()
 
 
+@pytest.mark.supported_speos_versions(max=251)
+def test_create_virtual_bsdf_bench_unsupported(speos: Speos):
+    """Test creation of Virtual BSDF Bench Simulation on unsupported Speos versions."""
+    p = Project(speos=speos)
+    with pytest.raises(NotImplementedError, match="needs a Speos Version of 25 R1 SP1 or higher."):
+        p.create_simulation("virtual_bsdf_bench_1", feature_type=SimulationVirtualBSDF)
+
+
 @pytest.mark.supported_speos_versions(min=252)
 def test_create_virtual_bsdf_bench(speos: Speos):
     """Test creation of Virtual BSDF Bench Simulation."""

--- a/tests/core/test_simulation.py
+++ b/tests/core/test_simulation.py
@@ -566,7 +566,7 @@ def test_create_interactive(speos: Speos):
 def test_create_virtual_bsdf_bench_unsupported(speos: Speos):
     """Test creation of Virtual BSDF Bench Simulation on unsupported Speos versions."""
     p = Project(speos=speos)
-    with pytest.raises(NotImplementedError, match="needs a Speos Version of 25 R1 SP1 or higher."):
+    with pytest.raises(NotImplementedError, match="needs a Speos Version of 25 R2 SP1 or higher."):
         p.create_simulation("virtual_bsdf_bench_1", feature_type=SimulationVirtualBSDF)
 
 


### PR DESCRIPTION
## Description
- Core layer
Project feature
create_simulation method: check if VBB is available on server side. If not, raise an error
- Kernel layer
Scene feature
Improve the _check_texture_available so that there is no more need to create a Scene to know is the textures are available
Indeed, starting 26r1 version, the API checkVersion is available

## Issue linked


## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
