### PR TITLE
fix: nightly failure lightbox test str comparison

### DIFF
--- a/doc/changelog.d/1128.fixed.md
+++ b/doc/changelog.d/1128.fixed.md
@@ -1,0 +1,1 @@
+Nightly failure lightbox test str comparison

--- a/tests/core/test_component.py
+++ b/tests/core/test_component.py
@@ -164,7 +164,6 @@ def test_create_lightbox(speos: Speos):
     normalized_lb_1 = _normalize_json_value(json.loads(lb_str1))
     normalized_lb_2 = _normalize_json_value(json.loads(lb_str2))
     assert normalized_lb_1 == normalized_lb_2
-    assert lb_str1 == lb_str2
     lightbox3 = p.create_lightbox(
         name="Light Box Import.3",
         lightbox=LightBoxFileInstance(

--- a/tests/core/test_component.py
+++ b/tests/core/test_component.py
@@ -22,6 +22,7 @@
 
 """Test basic using component."""
 
+import json
 from pathlib import Path
 
 import pytest
@@ -37,6 +38,19 @@ from ansys.speos.core.simulation import (
 from ansys.speos.core.source import SourceRayFile, SourceSurface
 from tests.conftest import test_path
 from tests.helper import does_file_exist, remove_file
+
+
+def _normalize_json_value(value):
+    """Recursively normalize JSON values for order-insensitive comparison."""
+    if isinstance(value, dict):
+        return {key: _normalize_json_value(inner_value) for key, inner_value in value.items()}
+    if isinstance(value, list):
+        normalized_items = [_normalize_json_value(item) for item in value]
+        return sorted(
+            normalized_items,
+            key=lambda item: json.dumps(item, sort_keys=True),
+        )
+    return value
 
 
 @pytest.mark.supported_speos_versions(min=261)
@@ -141,8 +155,16 @@ def test_create_lightbox(speos: Speos):
     assert out_dict["scene"]["sources"][0]["name"] == "Surface.2:1"
     assert lightbox.get("name") == "Light Box Import.1"
 
-    assert str(lightbox) == lightbox.__str__()
+    # string comparison
+    lb_str1 = str(lightbox)
+    lb_str2 = lightbox.__str__()
 
+    # Compare the parsed JSON content after normalizing list order so that
+    # semantically equivalent payloads do not fail when list items are reordered.
+    normalized_lb_1 = _normalize_json_value(json.loads(lb_str1))
+    normalized_lb_2 = _normalize_json_value(json.loads(lb_str2))
+    assert normalized_lb_1 == normalized_lb_2
+    assert lb_str1 == lb_str2
     lightbox3 = p.create_lightbox(
         name="Light Box Import.3",
         lightbox=LightBoxFileInstance(
@@ -190,6 +212,15 @@ def test_create_lightbox(speos: Speos):
     assert len(sim.source_paths) == 1
 
     lightbox.delete()
+
+
+def test_compare_json_strings_ignoring_list_order():
+    """Test JSON string comparison when list order is not stable."""
+    lb_str1 = '{"test": ["test1", "test2"]}'
+    lb_str2 = '{"test": ["test2", "test1"]}'
+
+    assert lb_str1 != lb_str2
+    assert _normalize_json_value(json.loads(lb_str1)) == _normalize_json_value(json.loads(lb_str2))
 
 
 @pytest.mark.supported_speos_versions(min=261)


### PR DESCRIPTION
## Description
Change string comparison to not fail due to different metadata order

## Issue linked
None

## Checklist
- [x] I have tested my changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style guidelines of this project.
- [x] I have added appropriate tests (unit, integration, system).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have linked the issue or issues that are solved by the PR if any.
- [x] I have assigned this PR to myself.
- [x] I have made sure that the title of my PR follows [Conventional commits style](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. ``feat: add optical property``)
- [x] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).
